### PR TITLE
Update issue templates to remove title prefixes and standardize labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Something is broken
-title: "[bug] "
-labels: ["bug"]
+title: ""
+labels: ["Type: Bug"]
 assignees: []
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an improvement or new capability
-title: "[feature] "
-labels: ["enhancement"]
+title: ""
+labels: ["Type: Feature"]
 assignees: []
 ---
 


### PR DESCRIPTION
## Summary
This pull request updates the GitHub issue templates to improve labeling consistency and streamline the process for reporting bugs and requesting features.

**Issue template improvements:**

* Updated the `bug_report.md` template to use the label `"Type: Bug"` instead of `"bug"` and removed the default title prefix.
* Updated the `feature_request.md` template to use the label `"Type: Feature"` instead of `"enhancement"` and removed the default title prefix.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] CI / tooling

## Related issue

Closes #24 
