### PR TITLE
Enhance branch status workflow to prevent duplicate comments

### DIFF
--- a/.github/workflows/branch-status.yml
+++ b/.github/workflows/branch-status.yml
@@ -9,6 +9,9 @@ jobs:
   set-in-progress:
     name: 'Set "Status: In Progress" when a branch references an issue'
     runs-on: ubuntu-latest
+    concurrency:
+      group: branch-status-${{ github.repository }}-${{ github.event.ref || github.ref }}
+      cancel-in-progress: false
     # Only act on branch creation; the push trigger covers branches created
     # without a separate "create" event (e.g. first push of a new remote branch).
     if: >-
@@ -109,11 +112,29 @@ jobs:
                 labels: [STATUS_LABEL],
               });
 
+              const commentMarker = `<!-- branch-status:${branch}:${issueNumber}:in-progress -->`;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+
+              const hasExistingBranchComment = comments.some((comment) =>
+                typeof comment.body === 'string' && comment.body.includes(commentMarker)
+              );
+
+              if (hasExistingBranchComment) {
+                core.info(`Comment already exists for #${issueNumber} + branch ${branch} – skipping comment.`);
+                core.info(`Set "${STATUS_LABEL}" on #${issueNumber}.`);
+                continue;
+              }
+
               await github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number: issueNumber,
-                body: `🌿 Branch \`${branch}\` was created – status automatically set to **${STATUS_LABEL}**.`,
+                body: `${commentMarker}\n🌿 Branch \`${branch}\` was created – status automatically set to **${STATUS_LABEL}**.`,
               });
 
               core.info(`Set "${STATUS_LABEL}" on #${issueNumber}.`);

--- a/.github/workflows/branch-status.yml
+++ b/.github/workflows/branch-status.yml
@@ -10,7 +10,7 @@ jobs:
     name: 'Set "Status: In Progress" when a branch references an issue'
     runs-on: ubuntu-latest
     concurrency:
-      group: branch-status-${{ github.repository }}-${{ github.event.ref || github.ref }}
+      group: branch-status-${{ github.repository }}-${{ github.ref_name }}
       cancel-in-progress: false
     # Only act on branch creation; the push trigger covers branches created
     # without a separate "create" event (e.g. first push of a new remote branch).


### PR DESCRIPTION
## Summary


This pull request updates the `branch-status.yml` GitHub Actions workflow to improve how status comments are managed when a branch references an issue. The main focus is on preventing duplicate comments and ensuring workflow runs are properly grouped.

Workflow improvements:

* Added a `concurrency` group to the `set-in-progress` job to ensure only one workflow run per branch and repository is active at a time, preventing overlapping status updates.

Comment handling enhancements:

* Added a unique HTML comment marker to each status comment and updated the workflow to check for existing comments with this marker before posting a new one, preventing duplicate status comments on the same issue and branch.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / cleanup
- [x] CI / tooling

## Checklist

- [x] Tested locally (`docker compose up -d`)
- [x] Linters pass (`npm run lint` for TS, `ruff check` for Python)
- [x] `.env.example` updated if new env vars are added
- [x] `README.md` updated if behaviour or configuration changes

## Related issue

Closes #38 
