### PR TITLE
Simplify PR template by removing issue type and test checkboxes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,21 +2,6 @@
 
 <!-- What does this PR change and why? -->
 
-## Type of change
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Documentation
-- [ ] Refactor / cleanup
-- [ ] CI / tooling
-
-## Checklist
-
-- [ ] Tested locally (`docker compose up -d`)
-- [ ] Linters pass (`npm run lint` for TS, `ruff check` for Python)
-- [ ] `.env.example` updated if new env vars are added
-- [ ] `README.md` updated if behaviour or configuration changes
-
 ## Related issue
 
 Closes #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,5 +36,5 @@ This repository accepts AI-assisted changes, but agents should follow the same s
 ## Pull Request Expectations
 
 - Update `README.md` when behavior or configuration changes.
-- Keep the PR template checklist accurate.
+- Keep the PR template sections (Summary, Related issue) accurate and complete.
 - Reference the related issue when one exists.


### PR DESCRIPTION
## Summary
This pull request streamlines the pull request template by removing the "Type of change" and "Checklist" sections, making the template simpler and more focused.

Template simplification:

* Removed the "Type of change" section, which previously asked contributors to specify the nature of their change.
* Removed the "Checklist" section, which included reminders for local testing, linting, and documentation updates.


## Related issue

Closes #41 
