### PR TITLE
Centralize documentation links across files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,8 @@ assignees: []
 
 <!-- A clear description of what is wrong. -->
 
+Reference the relevant docs page when possible: https://docs.sonicverse.eu
+
 ## Steps to reproduce
 
 1.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,6 +10,8 @@ assignees: []
 
 <!-- What are you trying to do that you currently cannot? -->
 
+Reference the related docs page when possible: https://docs.sonicverse.eu
+
 ## Proposed solution
 
 <!-- Describe the feature. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 <!-- What does this PR change and why? -->
 
+<!-- Primary documentation source: https://docs.sonicverse.eu -->
+
 ## Related issue
 
 Closes #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 This repository accepts AI-assisted changes, but agents should follow the same standards as human contributors in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Primary project documentation is maintained at **https://docs.sonicverse.eu** and should be treated as the source of truth for setup and operations.
+MCP documentation: **https://docs.sonicverse.eu/mcp**
 
 ## Scope
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This repository accepts AI-assisted changes, but agents should follow the same standards as human contributors in [CONTRIBUTING.md](CONTRIBUTING.md).
 
+Primary project documentation is maintained at **https://docs.sonicverse.eu** and should be treated as the source of truth for setup and operations.
+
 ## Scope
 
 - Keep changes focused on one bug fix, feature, or cleanup.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing. This document covers how to get started, submit changes, and report issues.
 
+Primary documentation lives at **https://docs.sonicverse.eu**. Use it as the canonical source for setup and operational guidance.
+
 If you are using an AI coding agent, also follow [AGENTS.md](AGENTS.md).
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@
 
 Self-hosted Docker Compose stack for live radio streaming. Ingest from any studio encoder, deliver via Icecast2 and HLS adaptive bitrate, with automatic fallback, silence detection, PostHog analytics, Pushover alerts, and a real-time operator dashboard.
 
+## Documentation
+
+For setup, operations, and troubleshooting, use the official Sonicverse docs as the single source of truth:
+
+**https://docs.sonicverse.eu**
+
+This repository README is a quick project overview. If local instructions differ from the external docs, follow docs.sonicverse.eu.
+
 Join the Sonicverse OSS Slack for community support, implementation questions, and contributor collaboration.
 
 ## Architecture

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Policy
 
+Primary project documentation is maintained at **https://docs.sonicverse.eu**. This file covers only security reporting expectations for this repository.
+
 ## Supported Versions
 
 | Version | Supported |


### PR DESCRIPTION
## Summary
This pull request updates project documentation files to clarif#35 t the official and canonical documentation is hosted at https://docs.sonicverse.eu. Contributors and users are directed to treat this external documentation as the primary source for setup, operations, and troubleshooting, ensuring consistency across all project guidance.

Documentation updates:

* Added explicit statements to `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and `SECURITY.md` directing users to https://docs.sonicverse.eu as the authoritative source for project documentation, setup, and operational guidance. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R10-R17) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R5-R6) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R5-R6) [[4]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7R3-R4)

## Related issue

Closes #35 
