### PR TITLE
feat: add Code of Conduct to establish community guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -23,6 +23,20 @@ Participants in this project are expected to:
 
 Report conduct issues to `oss@sonicverse.eu`.
 
+This inbox is maintained by `@rikvisser-dev` from Sonicverse.
+
+When reporting, please include (if available):
+
+- links to relevant comments, commits, issues, or pull requests
+- timestamps/timezone and involved usernames or accounts
+- screenshots, logs, or other supporting evidence
+
+Reports are handled confidentially and shared only with maintainers who need the information to investigate and respond.
+
+We aim to acknowledge reports within 72 hours on a best-effort basis.
+
+If you cannot access email, send a direct message to `@rikvisser-dev` on Slack: [Slack DM deep link](https://sonicverse-oss.slack.com/messages/@rikvisser-dev).
+
 ## Enforcement
 
 Project maintainers may remove, edit, or reject comments, commits, code, issues, and contributions that violate this policy. Maintainers may also temporarily or permanently restrict participation when necessary.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Code of Conduct
+
+## Our commitment
+
+Sonicverse is committed to a welcoming, respectful, and technically serious open-source environment.
+
+Participants in this project are expected to:
+
+- be respectful and direct
+- assume good faith while discussing technical disagreements
+- keep criticism focused on ideas, code, and decisions
+- avoid harassment, discrimination, intimidation, and personal attacks
+
+## Unacceptable behavior
+
+- harassment or abusive language
+- discriminatory remarks
+- deliberate intimidation
+- repeated bad-faith disruption
+- publishing private information without permission
+
+## Reporting
+
+Report conduct issues to `oss@sonicverse.eu`.
+
+## Enforcement
+
+Project maintainers may remove, edit, or reject comments, commits, code, issues, and contributions that violate this policy. Maintainers may also temporarily or permanently restrict participation when necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ Thank you for your interest in contributing. This document covers how to get sta
 
 Primary documentation lives at **https://docs.sonicverse.eu**. Use it as the canonical source for setup and operational guidance.
 
+## Code of Conduct
+
+This project follows [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). By participating, you agree to follow its expectations for respectful and constructive collaboration.
+
 If you are using an AI coding agent, also follow [AGENTS.md](AGENTS.md).
 
 ## Getting Started
@@ -80,6 +84,8 @@ If your change introduces new environment variables:
 ## Reporting Bugs
 
 Use the **Bug report** issue template. Include your OS, Docker version, and relevant logs (`docker compose logs --tail=50 <service>`).
+
+For behavioral or conduct concerns, report through the process in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## Security Issues
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ For setup, operations, and troubleshooting, use the official Sonicverse docs as 
 
 This repository README is a quick project overview. If local instructions differ from the external docs, follow docs.sonicverse.eu.
 
+Contributing to this project means following the [Code of Conduct](CODE_OF_CONDUCT.md).
+
 Join the Sonicverse OSS Slack for community support, implementation questions, and contributor collaboration.
 
 ## Architecture

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,8 @@ Primary project documentation is maintained at **https://docs.sonicverse.eu**. T
 
 Please use [GitHub's private vulnerability reporting](https://github.com/sonicverse-eu/audiostreaming-stack/security/advisories/new) to disclose issues confidentially.
 
+This channel is for security vulnerabilities only. For conduct-related concerns, follow the reporting process in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
 Include the following in your report:
 - Description of the vulnerability
 - Steps to reproduce


### PR DESCRIPTION
## Summary

This pull request adds a new Code of Conduct to the repository, outlining expected behaviors, unacceptable conduct, and reporting/enforcement procedures.

Project governance:

* Added a `CODE_OF_CONDUCT.md` file that defines community standards for respectful and inclusive participation, lists unacceptable behaviors, and provides guidance for reporting and enforcement.

## Related issue

Closes #50 
