### PR TITLE
Enhance Docker image digest validation for platform consistency

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -211,14 +211,39 @@ jobs:
           dockerhub_ref="docker.io/${DOCKERHUB_USERNAME}/audiostreaming-stack-${{ matrix.service.name }}"
           dockerhub_ref="${dockerhub_ref}:sha-${short_sha}"
 
-          ghcr_digest="$(docker buildx imagetools inspect "$ghcr_ref" --format '{{.Manifest.Digest}}')"
-          dockerhub_digest="$(docker buildx imagetools inspect "$dockerhub_ref" --format '{{.Manifest.Digest}}')"
+          platforms="${{ matrix.service.platforms || 'linux/amd64,linux/arm64' }}"
 
-          echo "GHCR digest:      $ghcr_digest"
-          echo "Docker Hub digest: $dockerhub_digest"
+          normalize_manifest() {
+            local ref="$1"
 
-          if [[ "$ghcr_digest" != "$dockerhub_digest" ]]; then
-            echo "Digest mismatch between GHCR and Docker Hub for ${{ matrix.service.name }}" >&2
+            docker buildx imagetools inspect "$ref" --format '{{json .Manifest.Manifests}}' \
+              | jq -r --arg platforms "$platforms" '
+                  ($platforms | split(",") | map(split("/") | {os: .[0], architecture: .[1]}) | INDEX(.os + "/" + .architecture)) as $wanted
+                  | map(select(.Platform != null))
+                  | map(select(.Platform.os != "unknown" and .Platform.architecture != "unknown"))
+                  | map(select($wanted[(.Platform.os + "/" + .Platform.architecture)] != null))
+                  | map({platform: (.Platform.os + "/" + .Platform.architecture), digest: .Digest})
+                  | sort_by(.platform)
+                  | .[]
+                  | "\(.platform)=\(.digest)"'
+          }
+
+          ghcr_manifest="$(normalize_manifest "$ghcr_ref")"
+          dockerhub_manifest="$(normalize_manifest "$dockerhub_ref")"
+
+          echo "Expected platforms: $platforms"
+          echo "GHCR platform digests:"
+          echo "$ghcr_manifest"
+          echo "Docker Hub platform digests:"
+          echo "$dockerhub_manifest"
+
+          if [[ -z "$ghcr_manifest" || -z "$dockerhub_manifest" ]]; then
+            echo "Unable to resolve runtime platform manifests for ${{ matrix.service.name }}" >&2
+            exit 1
+          fi
+
+          if [[ "$ghcr_manifest" != "$dockerhub_manifest" ]]; then
+            echo "Runtime platform digest mismatch between GHCR and Docker Hub for ${{ matrix.service.name }}" >&2
             exit 1
           fi
 

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -54,16 +54,16 @@ jobs:
       - name: Compute docs-only change flag
         id: docs_only
         run: |
-          set -e
+          set -euo pipefail
           docs_only=false
           if [[ "${{ steps.filter.outputs.docs }}" == 'true' && \
                 "${{ steps.filter.outputs.affects_all }}" == 'false' && \
                 "${{ steps.filter.outputs.icecast }}" == 'false' && \
                 "${{ steps.filter.outputs.liquidsoap }}" == 'false' && \
                 "${{ steps.filter.outputs.nginx }}" == 'false' && \
-                    "${{ steps.filter.outputs.status_api }}" == 'false' && \
+                "${{ steps.filter.outputs.status_api }}" == 'false' && \
                 "${{ steps.filter.outputs.analytics }}" == 'false' ]]; then
-                docs_only=true
+              docs_only=true
           fi
           echo "value=$docs_only" >> "$GITHUB_OUTPUT"
 
@@ -80,54 +80,54 @@ jobs:
       - name: Build dynamic matrix
         id: matrix
         run: |
-          set -e
+          set -euo pipefail
 
           matrix='{"service":['
           sep=''
 
           add_service() {
-            local name="$1"
-            local context="$2"
-            local platforms="$3"
-            local runner="$4"
+              local name="$1"
+              local context="$2"
+              local platforms="$3"
+              local runner="$4"
 
-            matrix+="$sep{\"name\":\"$name\",\"context\":\"$context\""
-            if [[ -n "$platforms" ]]; then
-              matrix+=",\"platforms\":\"$platforms\""
-            fi
-            if [[ -n "$runner" ]]; then
-              matrix+=",\"runner\":\"$runner\""
-            fi
-            matrix+="}"
-            sep=','
+              matrix+="$sep{\"name\":\"$name\",\"context\":\"$context\""
+              if [[ -n "$platforms" ]]; then
+                  matrix+=",\"platforms\":\"$platforms\""
+              fi
+              if [[ -n "$runner" ]]; then
+                  matrix+=",\"runner\":\"$runner\""
+              fi
+              matrix+="}"
+              sep=','
           }
 
           if [[ "${{ github.event_name }}" != 'pull_request' || \
                 "${{ steps.filter.outputs.affects_all }}" == 'true' ]]; then
-            add_service icecast ./services/streaming/icecast \
-              linux/amd64,linux/arm64,linux/386 \
-              blacksmith-8vcpu-ubuntu-2404
-            add_service liquidsoap ./services/streaming/liquidsoap linux/amd64,linux/arm64 ''
-            add_service nginx ./infrastructure/nginx \
-              linux/amd64,linux/arm64,linux/386 \
-              blacksmith-8vcpu-ubuntu-2404
-            add_service status-api ./apps/status-api linux/amd64 ''
-            add_service analytics ./services/analytics linux/amd64,linux/arm64 ''
-          elif [[ "${{ steps.docs_only.outputs.value }}" != 'true' ]]; then
-            [[ "${{ steps.filter.outputs.icecast }}" == 'true' ]] && \
               add_service icecast ./services/streaming/icecast \
-                linux/amd64,linux/arm64,linux/386 \
-                blacksmith-8vcpu-ubuntu-2404
-            [[ "${{ steps.filter.outputs.liquidsoap }}" == 'true' ]] && \
+                  linux/amd64,linux/arm64,linux/386 \
+                  blacksmith-8vcpu-ubuntu-2404
               add_service liquidsoap ./services/streaming/liquidsoap linux/amd64,linux/arm64 ''
-            [[ "${{ steps.filter.outputs.nginx }}" == 'true' ]] && \
               add_service nginx ./infrastructure/nginx \
-                linux/amd64,linux/arm64,linux/386 \
-                blacksmith-8vcpu-ubuntu-2404
-            [[ "${{ steps.filter.outputs.status_api }}" == 'true' ]] && \
+                  linux/amd64,linux/arm64,linux/386 \
+                  blacksmith-8vcpu-ubuntu-2404
               add_service status-api ./apps/status-api linux/amd64 ''
-            [[ "${{ steps.filter.outputs.analytics }}" == 'true' ]] && \
               add_service analytics ./services/analytics linux/amd64,linux/arm64 ''
+          elif [[ "${{ steps.docs_only.outputs.value }}" != 'true' ]]; then
+              [[ "${{ steps.filter.outputs.icecast }}" == 'true' ]] && \
+                  add_service icecast ./services/streaming/icecast \
+                      linux/amd64,linux/arm64,linux/386 \
+                      blacksmith-8vcpu-ubuntu-2404
+              [[ "${{ steps.filter.outputs.liquidsoap }}" == 'true' ]] && \
+                  add_service liquidsoap ./services/streaming/liquidsoap linux/amd64,linux/arm64 ''
+              [[ "${{ steps.filter.outputs.nginx }}" == 'true' ]] && \
+                  add_service nginx ./infrastructure/nginx \
+                      linux/amd64,linux/arm64,linux/386 \
+                      blacksmith-8vcpu-ubuntu-2404
+              [[ "${{ steps.filter.outputs.status_api }}" == 'true' ]] && \
+                  add_service status-api ./apps/status-api linux/amd64 ''
+              [[ "${{ steps.filter.outputs.analytics }}" == 'true' ]] && \
+                  add_service analytics ./services/analytics linux/amd64,linux/arm64 ''
           fi
 
           matrix+=']}'
@@ -165,10 +165,10 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          set -e
+          set -euo pipefail
           if [[ -z "$DOCKERHUB_USERNAME" || -z "$DOCKERHUB_TOKEN" ]]; then
-            echo "Missing Docker Hub credentials: set DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets." >&2
-            exit 1
+              echo "Missing Docker Hub credentials: set DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets." >&2
+              exit 1
           fi
 
       - name: Log in to GHCR
@@ -218,7 +218,7 @@ jobs:
         env:
           DOCKERHUB_USERNAME: ${{ env.DOCKERHUB_NAMESPACE }}
         run: |
-          set -e
+          set -euo pipefail
           short_sha="${GITHUB_SHA::7}"
           ghcr_ref="${{ env.GHCR_IMAGE_BASE }}/${{ matrix.service.name }}:sha-${short_sha}"
           dockerhub_ref="docker.io/${DOCKERHUB_USERNAME}/audiostreaming-stack-${{ matrix.service.name }}"
@@ -227,50 +227,54 @@ jobs:
           platforms="${{ matrix.service.platforms || 'linux/amd64,linux/arm64' }}"
 
           normalize_manifest() {
-            local ref="$1"
+              local ref="$1"
 
-            docker buildx imagetools inspect "$ref" --format '{{json .Manifest.Manifests}}' \
-              | jq -c --arg platforms "$platforms" '
-                  ($platforms
-                    | split(",")
-                    | map(gsub("^ +| +$"; ""))
-                    | map(split("/"))
-                    | map({os: .[0], architecture: .[1]})
-                    | INDEX(.os + "/" + .architecture)
-                  ) as $wanted
-                  | map(select(.Platform != null))
-                  | map(select(.Platform.os != "unknown" and .Platform.architecture != "unknown"))
-                  | map(select($wanted[(.Platform.os + "/" + .Platform.architecture)] != null))
-                  | map({
-                      key: (.Platform.os + "/" + .Platform.architecture),
-                      value: .Digest
-                    })
-                  | from_entries'
+              docker buildx imagetools inspect "$ref" --format '{{json .Manifest.Manifests}}' \
+                  | jq -c --arg platforms "$platforms" '
+                      def pkey($p):
+                        ($p.os + "/" + $p.architecture)
+                        + (if (($p.variant // "") != "") then "/" + $p.variant else "" end);
+                      ($platforms
+                        | split(",")
+                        | map(gsub("^ +| +$"; ""))
+                        | map(split("/"))
+                        | map({
+                            os: .[0],
+                            architecture: .[1],
+                            variant: (.[2] // "")
+                          })
+                        | INDEX(pkey(.))
+                      ) as $wanted
+                      | map(select(.Platform != null))
+                      | map(select(.Platform.os != "unknown" and .Platform.architecture != "unknown"))
+                      | map(select($wanted[pkey(.Platform)] != null))
+                      | map({key: pkey(.Platform), value: .Digest})
+                      | from_entries'
           }
 
           ghcr_manifest="$(normalize_manifest "$ghcr_ref")"
           dockerhub_manifest="$(normalize_manifest "$dockerhub_ref")"
 
           expected_list="$(
-            printf '%s\n' "$platforms" \
-              | tr ',' '\n' \
-              | sed 's/^ *//;s/ *$//' \
-              | sort -u
+              printf '%s\n' "$platforms" \
+                  | tr ',' '\n' \
+                  | sed 's/^ *//;s/ *$//' \
+                  | sort -u
           )"
 
           ghcr_list="$(echo "$ghcr_manifest" | jq -r 'keys[]' | sort -u)"
           dockerhub_list="$(echo "$dockerhub_manifest" | jq -r 'keys[]' | sort -u)"
 
           missing_ghcr="$(
-            comm -23 \
-              <(printf '%s\n' "$expected_list") \
-              <(printf '%s\n' "$ghcr_list")
+              comm -23 \
+                  <(printf '%s\n' "$expected_list") \
+                  <(printf '%s\n' "$ghcr_list")
           )"
 
           missing_dockerhub="$(
-            comm -23 \
-              <(printf '%s\n' "$expected_list") \
-              <(printf '%s\n' "$dockerhub_list")
+              comm -23 \
+                  <(printf '%s\n' "$expected_list") \
+                  <(printf '%s\n' "$dockerhub_list")
           )"
 
           echo "Expected platforms: $platforms"
@@ -278,44 +282,44 @@ jobs:
           echo "Docker Hub platform map: $dockerhub_manifest"
 
           if [[ -n "$missing_ghcr" ]]; then
-            echo "GHCR is missing expected platform(s) for ${{ matrix.service.name }}:" >&2
-            printf '%s\n' "$missing_ghcr" >&2
-            exit 1
+              echo "GHCR is missing expected platform(s) for ${{ matrix.service.name }}:" >&2
+              printf '%s\n' "$missing_ghcr" >&2
+              exit 1
           fi
 
           if [[ -n "$missing_dockerhub" ]]; then
-            echo "Docker Hub is missing expected platform(s) for ${{ matrix.service.name }}:" >&2
-            printf '%s\n' "$missing_dockerhub" >&2
-            exit 1
+              echo "Docker Hub is missing expected platform(s) for ${{ matrix.service.name }}:" >&2
+              printf '%s\n' "$missing_dockerhub" >&2
+              exit 1
           fi
 
           if [[ -z "$ghcr_manifest" || -z "$dockerhub_manifest" ]]; then
-            echo "Unable to resolve runtime platform manifests for ${{ matrix.service.name }}" >&2
-            exit 1
+              echo "Unable to resolve runtime platform manifests for ${{ matrix.service.name }}" >&2
+              exit 1
           fi
 
           digest_mismatch="$(
-            jq -n \
-              --argjson ghcr "$ghcr_manifest" \
-              --argjson dockerhub "$dockerhub_manifest" \
-              --arg platforms "$platforms" '
-                ($platforms | split(",") | map(gsub("^ +| +$"; ""))) as $expected
-                | [
-                    $expected[]
-                    | select($ghcr[.] != $dockerhub[.])
-                    | {
-                        platform: .,
-                        ghcr: $ghcr[.],
-                        dockerhub: $dockerhub[.]
-                      }
-                  ]
-              '
+              jq -n \
+                  --argjson ghcr "$ghcr_manifest" \
+                  --argjson dockerhub "$dockerhub_manifest" \
+                  --arg platforms "$platforms" '
+                    ($platforms | split(",") | map(gsub("^ +| +$"; ""))) as $expected
+                    | [
+                        $expected[]
+                        | select($ghcr[.] != $dockerhub[.])
+                        | {
+                            platform: .,
+                            ghcr: $ghcr[.],
+                            dockerhub: $dockerhub[.]
+                          }
+                      ]
+                  '
           )"
 
           if [[ "$(echo "$digest_mismatch" | jq 'length')" -gt 0 ]]; then
-            echo "Runtime platform digest mismatch between GHCR and Docker Hub for ${{ matrix.service.name }}" >&2
-            echo "$digest_mismatch" >&2
-            exit 1
+              echo "Runtime platform digest mismatch between GHCR and Docker Hub for ${{ matrix.service.name }}" >&2
+              echo "$digest_mismatch" >&2
+              exit 1
           fi
 
   docs-only:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -39,6 +39,7 @@ jobs:
               - '**/*.md'
             affects_all:
               - 'docker-compose.yml'
+              - '.github/workflows/docker-build-push.yml'
             icecast:
               - 'services/streaming/icecast/**'
             liquidsoap:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -89,10 +89,14 @@ jobs:
             local name="$1"
             local context="$2"
             local platforms="$3"
+            local runner="$4"
 
             matrix+="$sep{\"name\":\"$name\",\"context\":\"$context\""
             if [[ -n "$platforms" ]]; then
               matrix+=",\"platforms\":\"$platforms\""
+            fi
+            if [[ -n "$runner" ]]; then
+              matrix+=",\"runner\":\"$runner\""
             fi
             matrix+="}"
             sep=','
@@ -100,22 +104,30 @@ jobs:
 
           if [[ "${{ github.event_name }}" != 'pull_request' || \
                 "${{ steps.filter.outputs.affects_all }}" == 'true' ]]; then
-            add_service icecast ./services/streaming/icecast ''
-            add_service liquidsoap ./services/streaming/liquidsoap linux/amd64,linux/arm64
-            add_service nginx ./infrastructure/nginx ''
-            add_service status-api ./apps/status-api linux/amd64
-            add_service analytics ./services/analytics ''
+            add_service icecast ./services/streaming/icecast \
+              linux/amd64,linux/arm64,linux/386 \
+              blacksmith-8vcpu-ubuntu-2404
+            add_service liquidsoap ./services/streaming/liquidsoap linux/amd64,linux/arm64 ''
+            add_service nginx ./infrastructure/nginx \
+              linux/amd64,linux/arm64,linux/386 \
+              blacksmith-8vcpu-ubuntu-2404
+            add_service status-api ./apps/status-api linux/amd64 ''
+            add_service analytics ./services/analytics linux/amd64,linux/arm64 ''
           elif [[ "${{ steps.docs_only.outputs.value }}" != 'true' ]]; then
             [[ "${{ steps.filter.outputs.icecast }}" == 'true' ]] && \
-              add_service icecast ./services/streaming/icecast ''
+              add_service icecast ./services/streaming/icecast \
+                linux/amd64,linux/arm64,linux/386 \
+                blacksmith-8vcpu-ubuntu-2404
             [[ "${{ steps.filter.outputs.liquidsoap }}" == 'true' ]] && \
-              add_service liquidsoap ./services/streaming/liquidsoap linux/amd64,linux/arm64
+              add_service liquidsoap ./services/streaming/liquidsoap linux/amd64,linux/arm64 ''
             [[ "${{ steps.filter.outputs.nginx }}" == 'true' ]] && \
-              add_service nginx ./infrastructure/nginx ''
+              add_service nginx ./infrastructure/nginx \
+                linux/amd64,linux/arm64,linux/386 \
+                blacksmith-8vcpu-ubuntu-2404
             [[ "${{ steps.filter.outputs.status_api }}" == 'true' ]] && \
-              add_service status-api ./apps/status-api linux/amd64
+              add_service status-api ./apps/status-api linux/amd64 ''
             [[ "${{ steps.filter.outputs.analytics }}" == 'true' ]] && \
-              add_service analytics ./services/analytics ''
+              add_service analytics ./services/analytics linux/amd64,linux/arm64 ''
           fi
 
           matrix+=']}'
@@ -124,7 +136,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.service.name }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ matrix.service.runner || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: changes
     if: >-
       (github.event_name == 'pull_request' && needs.changes.outputs.docs_only != 'true') ||
@@ -218,33 +230,91 @@ jobs:
             local ref="$1"
 
             docker buildx imagetools inspect "$ref" --format '{{json .Manifest.Manifests}}' \
-              | jq -r --arg platforms "$platforms" '
-                  ($platforms | split(",") | map(split("/") | {os: .[0], architecture: .[1]}) | INDEX(.os + "/" + .architecture)) as $wanted
+              | jq -c --arg platforms "$platforms" '
+                  ($platforms
+                    | split(",")
+                    | map(gsub("^ +| +$"; ""))
+                    | map(split("/"))
+                    | map({os: .[0], architecture: .[1]})
+                    | INDEX(.os + "/" + .architecture)
+                  ) as $wanted
                   | map(select(.Platform != null))
                   | map(select(.Platform.os != "unknown" and .Platform.architecture != "unknown"))
                   | map(select($wanted[(.Platform.os + "/" + .Platform.architecture)] != null))
-                  | map({platform: (.Platform.os + "/" + .Platform.architecture), digest: .Digest})
-                  | sort_by(.platform)
-                  | .[]
-                  | "\(.platform)=\(.digest)"'
+                  | map({
+                      key: (.Platform.os + "/" + .Platform.architecture),
+                      value: .Digest
+                    })
+                  | from_entries'
           }
 
           ghcr_manifest="$(normalize_manifest "$ghcr_ref")"
           dockerhub_manifest="$(normalize_manifest "$dockerhub_ref")"
 
+          expected_list="$(
+            printf '%s\n' "$platforms" \
+              | tr ',' '\n' \
+              | sed 's/^ *//;s/ *$//' \
+              | sort -u
+          )"
+
+          ghcr_list="$(echo "$ghcr_manifest" | jq -r 'keys[]' | sort -u)"
+          dockerhub_list="$(echo "$dockerhub_manifest" | jq -r 'keys[]' | sort -u)"
+
+          missing_ghcr="$(
+            comm -23 \
+              <(printf '%s\n' "$expected_list") \
+              <(printf '%s\n' "$ghcr_list")
+          )"
+
+          missing_dockerhub="$(
+            comm -23 \
+              <(printf '%s\n' "$expected_list") \
+              <(printf '%s\n' "$dockerhub_list")
+          )"
+
           echo "Expected platforms: $platforms"
-          echo "GHCR platform digests:"
-          echo "$ghcr_manifest"
-          echo "Docker Hub platform digests:"
-          echo "$dockerhub_manifest"
+          echo "GHCR platform map: $ghcr_manifest"
+          echo "Docker Hub platform map: $dockerhub_manifest"
+
+          if [[ -n "$missing_ghcr" ]]; then
+            echo "GHCR is missing expected platform(s) for ${{ matrix.service.name }}:" >&2
+            printf '%s\n' "$missing_ghcr" >&2
+            exit 1
+          fi
+
+          if [[ -n "$missing_dockerhub" ]]; then
+            echo "Docker Hub is missing expected platform(s) for ${{ matrix.service.name }}:" >&2
+            printf '%s\n' "$missing_dockerhub" >&2
+            exit 1
+          fi
 
           if [[ -z "$ghcr_manifest" || -z "$dockerhub_manifest" ]]; then
             echo "Unable to resolve runtime platform manifests for ${{ matrix.service.name }}" >&2
             exit 1
           fi
 
-          if [[ "$ghcr_manifest" != "$dockerhub_manifest" ]]; then
+          digest_mismatch="$(
+            jq -n \
+              --argjson ghcr "$ghcr_manifest" \
+              --argjson dockerhub "$dockerhub_manifest" \
+              --arg platforms "$platforms" '
+                ($platforms | split(",") | map(gsub("^ +| +$"; ""))) as $expected
+                | [
+                    $expected[]
+                    | select($ghcr[.] != $dockerhub[.])
+                    | {
+                        platform: .,
+                        ghcr: $ghcr[.],
+                        dockerhub: $dockerhub[.]
+                      }
+                  ]
+              '
+          )"
+
+          if [[ "$(echo "$digest_mismatch" | jq 'length')" -gt 0 ]]; then
             echo "Runtime platform digest mismatch between GHCR and Docker Hub for ${{ matrix.service.name }}" >&2
+            echo "$digest_mismatch" >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,11 @@ This installs **only what's needed to run**:
 Pre-built service images are published to both registries:
 
 - **Primary (default): Docker Hub** under `sonicverse`.
-- **Mirror: GHCR** under `ghcr.io/sonicverse-eu/audiostreaming-stack`.
+- **Mirror:** GHCR under `ghcr.io/sonicverse-eu/audiostreaming-stack`.
+
+The Build & Push Docker Images workflow verifies cross-registry parity per expected runtime platform
+for `linux/amd64`, `linux/arm64`, and configured `linux/386` targets.
+The check fails when a required platform is missing in either registry or when per-platform digests differ.
 
 Docker Hub image names:
 


### PR DESCRIPTION
## Summary
This pull request updates the Docker image digest verification logic in the `.github/workflows/docker-build-push.yml` workflow to compare platform-specific digests rather than just the overall manifest digest. This makes the verification more robust, especially for multi-platform images.

**Improved Docker image verification:**

* Replaces the previous digest comparison with a new `normalize_manifest` function that extracts and compares per-platform digests for both GHCR and Docker Hub images, ensuring all expected platforms match.
* Adds clearer logging of expected platforms and the per-platform digests for both registries, and improves error handling if manifests cannot be resolved.
<!-- Primary documentation source: https://docs.sonicverse.eu -->

## Related issue

Closes #58 
