### PR TITLE
fix: remove unrecognized `version` key from .coderabbit.yml

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 language: "en-US"
 
 tone_instructions: >

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,4 +1,5 @@
 language: "en-US"
+early_access: true
 
 tone_instructions: >
   Be concise and constructive. Focus on correctness, security, and maintainability.
@@ -12,9 +13,14 @@ reviews:
   auto_title_placeholder: "@coderabbitai"
   poem: false
   review_status: true
+  review_details: true
   collapse_walkthrough: false
   sequence_diagrams: true
   changed_files_summary: true
+  in_progress_fortune: false
+  pre_merge_checks:
+    issue_assessment:
+      mode: "warning"
   labeling_instructions:
     - label: "python"
       instructions: >
@@ -81,3 +87,16 @@ reviews:
 
 chat:
   auto_reply: true
+
+issue_enrichment:
+  auto_enrich:
+    enabled: true
+  planning:
+    enabled: true
+    auto_planning:
+      enabled: true
+      labels:
+        - "bug"
+        - "enhancement"
+        - "maintenance"
+        - "!wip"


### PR DESCRIPTION
### Motivation
- CodeRabbit reported a parsing warning for an unrecognized top-level `version` property in `.coderabbit.yml`, which should be removed to avoid schema validation noise.

### Description
- Removed the unsupported top-level `version` key from `.coderabbit.yml` and kept all existing valid CodeRabbit settings unchanged.

### Testing
- Parsed the file with Ruby YAML using `ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yml")'` which succeeded.
- Ran `yamllint -c .yamllint.yml .coderabbit.yml docker-compose.yml .github/workflows/` which failed in this environment because `yamllint` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3cafc36208320975cb7c399657df5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled early-access release channel.
  * Enhanced review experience with richer review details and in-progress status handling.
  * Chat-driven issue enrichment enabled and automatic issue planning activated using labels (bug, enhancement, maintenance, !wip).
  * Pre-merge issue assessment now issues warnings instead of blocking.

* **Chores**
  * Updated internal configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->