### PR TITLE
Update liquidsoap image to install patched libsndfile

### DIFF
--- a/services/streaming/liquidsoap/Dockerfile
+++ b/services/streaming/liquidsoap/Dockerfile
@@ -1,6 +1,11 @@
 FROM savonet/liquidsoap:v2.4.2
 
+# hadolint ignore=DL3002
 USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libsndfile1=1.2.2-2+deb13u1 && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY radio.liq /etc/liquidsoap/radio.liq
 


### PR DESCRIPTION
## Summary
- install `libsndfile1=1.2.2-2+deb13u1` in the `liquidsoap` image to address the vulnerable package version
- keep the existing root-user build behavior and document the hadolint exception for `DL3002`
- clean apt metadata after install to avoid leaving package lists in the image

## Related issue
- addresses the reported `libsndfile` vulnerability in `audiostreaming-stack/liquidsoap`

## Testing
- `hadolint services/streaming/liquidsoap/Dockerfile`
- `docker compose config --quiet`
- `docker compose build liquidsoap` could not be completed because the Docker daemon was unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated audio library dependency to improve streaming service reliability and stability.
  * Optimized container image layer caching and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->