### PR TITLE
Update nginx image to stable Alpine slim base

### DIFF
--- a/docs/INSTALL_SHORT_URL_SETUP.md
+++ b/docs/INSTALL_SHORT_URL_SETUP.md
@@ -111,7 +111,7 @@ For complete control, run your own redirect service:
 **Using Docker:**
 
 ```dockerfile
-FROM nginx:stable-alpine-slim
+FROM nginx:1.28.3-alpine-slim
 
 RUN echo '
 server {

--- a/docs/INSTALL_SHORT_URL_SETUP.md
+++ b/docs/INSTALL_SHORT_URL_SETUP.md
@@ -111,7 +111,7 @@ For complete control, run your own redirect service:
 **Using Docker:**
 
 ```dockerfile
-FROM nginx:alpine
+FROM nginx:stable-alpine-slim
 
 RUN echo '
 server {

--- a/infrastructure/nginx/Dockerfile
+++ b/infrastructure/nginx/Dockerfile
@@ -1,4 +1,6 @@
-FROM nginx:stable-alpine-slim
+FROM nginx:1.28.3-alpine-slim
+
+RUN apk add --no-cache gettext
 
 COPY nginx.conf /etc/nginx/nginx.conf.template
 COPY index.html.template /etc/nginx/index.html.template

--- a/infrastructure/nginx/Dockerfile
+++ b/infrastructure/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:stable-alpine-slim
 
 COPY nginx.conf /etc/nginx/nginx.conf.template
 COPY index.html.template /etc/nginx/index.html.template

--- a/infrastructure/nginx/Dockerfile
+++ b/infrastructure/nginx/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.28.3-alpine-slim
 
-RUN apk add --no-cache gettext
+RUN apk add --no-cache gettext=0.24.1-r1
 
 COPY nginx.conf /etc/nginx/nginx.conf.template
 COPY index.html.template /etc/nginx/index.html.template


### PR DESCRIPTION
## Summary
- switch the nginx container image from `nginx:alpine` to `nginx:stable-alpine-slim`
- reduce exposure to the vulnerable Alpine package set by rebuilding from the newer upstream base
- update the Docker example in `docs/INSTALL_SHORT_URL_SETUP.md` to match the production image choice

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image base variant for self-hosted NGINX redirect service deployment documentation and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->