### PR TITLE
Update liquidsoap image to install patched openssl-provider-legacy

### DIFF
--- a/services/streaming/liquidsoap/Dockerfile
+++ b/services/streaming/liquidsoap/Dockerfile
@@ -1,6 +1,13 @@
 FROM savonet/liquidsoap:v2.4.2
 
+ARG OPENSSL_PROVIDER_LEGACY_VERSION=3.5.4-1~deb13u2
+
 USER root
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        "openssl-provider-legacy=${OPENSSL_PROVIDER_LEGACY_VERSION}" && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY radio.liq /etc/liquidsoap/radio.liq
 


### PR DESCRIPTION
## Summary
- add a pinned `OPENSSL_PROVIDER_LEGACY_VERSION` build argument for the liquidsoap image
- install `openssl-provider-legacy` version `3.5.4-1~deb13u2` during image build
- clear APT package lists after install to keep the image layer clean

## Testing
- `docker compose config`
- `hadolint services/streaming/liquidsoap/Dockerfile` (reports existing `DL3002` warning about final `USER root`)
- Not run (not requested)