### PR TITLE
Update liquidsoap image to upgrade libfreetype6

### DIFF
--- a/services/streaming/liquidsoap/Dockerfile
+++ b/services/streaming/liquidsoap/Dockerfile
@@ -2,10 +2,17 @@ FROM savonet/liquidsoap:v2.4.2
 
 USER root
 
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --only-upgrade libfreetype6 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY radio.liq /etc/liquidsoap/radio.liq
 
 # Ensure HLS output directory is writable
 RUN mkdir -p /hls && chmod 777 /hls
+
+USER liquidsoap
 
 EXPOSE 8010 8011
 


### PR DESCRIPTION
## Summary
- upgrade `libfreetype6` during the `liquidsoap` image build to pick up the Debian security fix
- clear apt package lists after the upgrade to keep the image lean
- switch back to the `liquidsoap` user after the root-only package update step

## Related issue
- none

## Testing
- Not run (not requested)