### PR TITLE
Update liquidsoap image to install patched libpng

### DIFF
--- a/services/streaming/liquidsoap/Dockerfile
+++ b/services/streaming/liquidsoap/Dockerfile
@@ -1,6 +1,12 @@
 FROM savonet/liquidsoap:v2.4.2
 
+# hadolint ignore=DL3002
 USER root
+
+# Pull the patched Debian libpng build called out by the vulnerability report.
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends libpng16-16=1.6.48-1+deb13u4 \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY radio.liq /etc/liquidsoap/radio.liq
 


### PR DESCRIPTION
## Summary
- install `libpng16-16=1.6.48-1+deb13u4` in the `liquidsoap` Docker image to address the reported high-severity vulnerabilities
- keep the change scoped to `services/streaming/liquidsoap/Dockerfile`
- document the intentional root user with a `hadolint` ignore so the Dockerfile remains lint-clean

## Related issue
- fixes the reported `libpng` vulnerability findings for `audiostreaming-stack/liquidsoap`

## Testing
- `hadolint services/streaming/liquidsoap/Dockerfile`
- `docker compose config`
- full image rebuild not run because the Docker daemon was unavailable in the working environment