### PR TITLE
Update liquidsoap base image to latest 2.4.x release

### DIFF
--- a/services/streaming/liquidsoap/Dockerfile
+++ b/services/streaming/liquidsoap/Dockerfile
@@ -1,4 +1,4 @@
-FROM savonet/liquidsoap:v2.4.2
+FROM savonet/liquidsoap:v2.4.x-latest
 
 USER root
 


### PR DESCRIPTION
## Summary
- update the `liquidsoap` Docker base image from `savonet/liquidsoap:v2.4.2` to `savonet/liquidsoap:v2.4.x-latest`
- pull in the latest upstream 2.4.x image rebuilds, including refreshed OS packages such as OpenSSL
- keep the service on the existing Liquidsoap 2.4 release line while avoiding a larger version jump

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Liquidsoap runtime to the latest v2.4.x version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->