### PR TITLE
Update liquidsoap image to upgrade dpkg during build

### DIFF
--- a/services/streaming/liquidsoap/Dockerfile
+++ b/services/streaming/liquidsoap/Dockerfile
@@ -1,6 +1,14 @@
 FROM savonet/liquidsoap:v2.4.2
 
+# hadolint ignore=DL3002
 USER root
+
+# Pull in the latest patched Debian package metadata so the image does not
+# inherit a vulnerable dpkg build from the upstream base layer.
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install --only-upgrade -y --no-install-recommends dpkg \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY radio.liq /etc/liquidsoap/radio.liq
 


### PR DESCRIPTION
## Summary
- upgrade `dpkg` in the `liquidsoap` image during build to pick up the patched Debian package version
- keep the existing upstream `savonet/liquidsoap:v2.4.2` base image and apply the fix with a minimal Dockerfile change
- add targeted `hadolint` ignores for the required `root` user switch and unpinned package upgrade

## Testing
- Not run (not requested)