### PR TITLE
fix: update status-api service to support linux/arm64 architecture

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -111,7 +111,7 @@ jobs:
               add_service nginx ./infrastructure/nginx \
                   linux/amd64,linux/arm64,linux/386 \
                   blacksmith-8vcpu-ubuntu-2404
-              add_service status-api ./apps/status-api linux/amd64 ''
+              add_service status-api ./apps/status-api linux/amd64,linux/arm64 ''
               add_service analytics ./services/analytics linux/amd64,linux/arm64 ''
           elif [[ "${{ steps.docs_only.outputs.value }}" != 'true' ]]; then
               [[ "${{ steps.filter.outputs.icecast }}" == 'true' ]] && \
@@ -125,7 +125,7 @@ jobs:
                       linux/amd64,linux/arm64,linux/386 \
                       blacksmith-8vcpu-ubuntu-2404
               [[ "${{ steps.filter.outputs.status_api }}" == 'true' ]] && \
-                  add_service status-api ./apps/status-api linux/amd64 ''
+                  add_service status-api ./apps/status-api linux/amd64,linux/arm64 ''
               [[ "${{ steps.filter.outputs.analytics }}" == 'true' ]] && \
                   add_service analytics ./services/analytics linux/amd64,linux/arm64 ''
           fi


### PR DESCRIPTION
## Summary
This pull request updates the Docker build workflow to add support for building the `status-api` service for both `linux/amd64` and `linux/arm64` architectures. This brings `status-api` in line with other services that already support multi-architecture builds.

**Docker build workflow improvements:**

* Updated the `add_service` commands in `.github/workflows/docker-build-push.yml` to build the `status-api` service for both `linux/amd64` and `linux/arm64` architectures, instead of just `linux/amd64`. [[1]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L114-R114) [[2]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L128-R128)

## Related issue

Closes #106 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended build platform support for the status-api service to include ARM64 architecture alongside existing AMD64 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->