### PR TITLE
Remove deprecated --no-parallel option from Docker Compose pull commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -218,8 +218,8 @@ if docker compose ps --quiet 2>/dev/null | head -1 | grep -q .; then
             info "Pulling latest changes..."
             git pull 2>/dev/null || true
             echo ""
-            info "Pulling latest images (sequential pull)..."
-            docker compose pull --no-parallel || true
+            info "Pulling latest images..."
+            docker compose pull || true
             echo ""
             info "Rebuilding any local images..."
             docker compose build
@@ -509,7 +509,7 @@ step "$STEP_NUM" "Building containers"
 if [ "$USE_PREBUILT" = "true" ]; then
     info "Pulling pre-built images from Docker Hub or configured registry..."
     echo ""
-    docker compose pull --no-parallel || { error "Pull failed. Images may not exist yet. Run with --build-local to build locally instead."; exit 1; }
+    docker compose pull || { error "Pull failed. Images may not exist yet. Run with --build-local to build locally instead."; exit 1; }
     echo ""
     success "All images pulled successfully"
 else


### PR DESCRIPTION
## Summary

This pull request makes a minor update to the `install.sh` script, specifically improving the way Docker images are pulled. The change removes the `--no-parallel` flag from the `docker compose pull` commands, allowing images to be pulled in parallel for faster execution.

- Docker image pulling:
  * Removed the `--no-parallel` flag from `docker compose pull` commands in `install.sh`, enabling parallel pulling of images and improving performance. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL221-R222) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL512-R512)

## Related issue

Closes #105 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized Docker image pulling for stack updates with pre-built images to use parallel downloads by default, improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->