### PR TITLE
docs: update agent instructions for Jira and Codacy MCP routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,5 +45,4 @@ MCP documentation: **https://docs.sonicverse.eu/mcp**
 
 - Update `README.md` when behavior or configuration changes.
 - Keep the PR template sections (Summary, Related issue) accurate and complete.
-- Pull requests must link to the correct related issue.
-- Reference the related issue when one exists.
+- Pull requests must link to the related issue when one exists.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ MCP documentation: **https://docs.sonicverse.eu/mcp**
 
 ## MCP Routing
 
-- If a reference begins with `SVAS-`, or mentions `Jira`, `jira`, or `Atlassian`, use the Jira MCP.
+- If a reference contains `SVAS-`, or mentions `Jira`, `jira`, or `Atlassian`, use the Jira MCP.
 - If you find a reference containing `Codacy` or `codacy`, use the Codacy MCP.
 
 ## Scope

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,11 @@ This repository accepts AI-assisted changes, but agents should follow the same s
 Primary project documentation is maintained at **https://docs.sonicverse.eu** and should be treated as the source of truth for setup and operations.
 MCP documentation: **https://docs.sonicverse.eu/mcp**
 
+## MCP Routing
+
+- If a reference begins with `SVAS-`, or mentions `Jira`, `jira`, or `Atlassian`, use the Jira MCP.
+- If you find a reference containing `Codacy` or `codacy`, use the Codacy MCP.
+
 ## Scope
 
 - Keep changes focused on one bug fix, feature, or cleanup.
@@ -40,4 +45,5 @@ MCP documentation: **https://docs.sonicverse.eu/mcp**
 
 - Update `README.md` when behavior or configuration changes.
 - Keep the PR template sections (Summary, Related issue) accurate and complete.
+- Pull requests must link to the correct related issue.
 - Reference the related issue when one exists.


### PR DESCRIPTION
## Summary
- Add MCP routing guidance to use Jira MCP for `SVAS-` references and Jira/Atlassian mentions
- Add MCP routing guidance to use Codacy MCP for references containing `Codacy` or `codacy`
- Clarify that pull requests must link to the correct related Jira issue
- Related issue: SVAS-18

## Testing
- Not run (not requested)