### PR TITLE
feat: add Codacy coverage reporter workflow

### DIFF
--- a/.github/workflows/codacy-coverage-reporter.yml
+++ b/.github/workflows/codacy-coverage-reporter.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   codacy-coverage-reporter:
     name: Upload coverage to Codacy
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 
@@ -40,7 +40,8 @@ jobs:
           seen_file="$(mktemp)"
 
           for pattern in "${patterns[@]}"; do
-              for report in $pattern; do
+              local_files=($pattern)
+              for report in "${local_files[@]}"; do
                   [[ -f "$report" ]] || continue
 
                   if ! grep -Fqx "$report" "$seen_file"; then
@@ -88,7 +89,7 @@ jobs:
         if: >-
           steps.coverage_reports.outputs.found == 'true' &&
           (secrets.CODACY_PROJECT_TOKEN != '' || secrets.CODACY_API_TOKEN != '')
-        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           api-token: ${{ secrets.CODACY_API_TOKEN }}

--- a/.github/workflows/codacy-coverage-reporter.yml
+++ b/.github/workflows/codacy-coverage-reporter.yml
@@ -1,0 +1,95 @@
+name: Codacy Coverage Reporter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  codacy-coverage-reporter:
+    name: Upload coverage to Codacy
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Discover coverage reports
+        id: coverage_reports
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+
+          patterns=(
+              "coverage.xml"
+              "**/coverage.xml"
+              "cobertura.xml"
+              "**/cobertura.xml"
+              "lcov.info"
+              "**/lcov.info"
+              "coverage/lcov.info"
+              "**/coverage/lcov.info"
+              ".coverage-reports/**/*.xml"
+              ".coverage-reports/**/*.info"
+          )
+
+          reports=()
+          seen_file="$(mktemp)"
+
+          for pattern in "${patterns[@]}"; do
+              for report in $pattern; do
+                  [[ -f "$report" ]] || continue
+
+                  if ! grep -Fqx "$report" "$seen_file"; then
+                      printf '%s\n' "$report" >> "$seen_file"
+                      reports+=("$report")
+                  fi
+              done
+          done
+
+          if [[ ${#reports[@]} -eq 0 ]]; then
+              echo "found=false" >> "$GITHUB_OUTPUT"
+              echo "files=" >> "$GITHUB_OUTPUT"
+              echo "No coverage reports were found. Skipping Codacy upload."
+              exit 0
+          fi
+
+          report_list="$(IFS=,; echo "${reports[*]}")"
+
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "files=$report_list" >> "$GITHUB_OUTPUT"
+          echo "Discovered coverage reports: $report_list"
+
+      - name: Skip upload when Codacy token is unavailable on pull requests
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.coverage_reports.outputs.found == 'true' &&
+          secrets.CODACY_PROJECT_TOKEN == '' &&
+          secrets.CODACY_API_TOKEN == ''
+        run: |
+          echo "Coverage reports were found, but no Codacy token is available in this pull request context."
+          echo "This is expected for pull requests from forks because GitHub does not expose repository secrets."
+
+      - name: Require Codacy token on main branch uploads
+        if: >-
+          github.event_name == 'push' &&
+          steps.coverage_reports.outputs.found == 'true' &&
+          secrets.CODACY_PROJECT_TOKEN == '' &&
+          secrets.CODACY_API_TOKEN == ''
+        run: |
+          echo "Coverage reports were found, but neither CODACY_PROJECT_TOKEN nor CODACY_API_TOKEN is configured." >&2
+          echo "Add one of those secrets before relying on Codacy coverage uploads from main." >&2
+          exit 1
+
+      - name: Upload coverage to Codacy
+        if: >-
+          steps.coverage_reports.outputs.found == 'true' &&
+          (secrets.CODACY_PROJECT_TOKEN != '' || secrets.CODACY_API_TOKEN != '')
+        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          api-token: ${{ secrets.CODACY_API_TOKEN }}
+          coverage-reports: ${{ steps.coverage_reports.outputs.files }}

--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ Alerts have a 5-minute cooldown to prevent spam.
 | Workflow | Trigger | Purpose |
 |---|---|---|
 | **Lint** | Push / PR to `main` | Runs component-aware checks: Ruff (Python), ESLint (TypeScript), hadolint (Dockerfiles), yamllint (YAML) |
+| **Codacy Coverage Reporter** | Push / PR to `main` | Uploads discovered coverage reports to Codacy when a Codacy token is configured |
 | **TruffleHog Secret Scan** | Push / PR to `main` | Scans commit history for verified leaked secrets using TruffleHog's CLI flags |
 | **Docker Build & Push** | Push / PR to `main`, tags `v*.*.*` | Builds service images and publishes to GHCR + Docker Hub; on PRs, only changed services are built |
 | **AI Autolabel Issues** | Issue opened / edited / reopened | Applies `Type:`, `Scope:`, and `Priority:` labels via GitHub Models (GPT-4o-mini) |
@@ -482,6 +483,35 @@ To reduce CI time and avoid unnecessary jobs, pull request checks are scoped by 
    - Builds only the services whose directories changed: `services/streaming/icecast/**`, `services/streaming/liquidsoap/**`, `infrastructure/nginx/**`, `apps/status-api/**`, `services/analytics/**`.
    - Builds all services when `docker-compose.yml` changes.
 - Pushes to `main` and release tags keep full coverage (no PR path filtering) for safety.
+
+### Codacy coverage reporting
+
+The Codacy coverage workflow lives in `.github/workflows/codacy-coverage-reporter.yml` and runs on pull requests to `main` plus pushes to `main`.
+
+To enable uploads:
+
+1. Add `CODACY_PROJECT_TOKEN` as a repository secret for this repository, or add `CODACY_API_TOKEN` as an organization secret if you manage multiple repositories from the same Codacy account.
+2. Ensure your build or test steps generate a supported coverage report before the Codacy upload step runs.
+3. Keep the coverage report inside the workspace so the workflow can discover it.
+
+The workflow currently auto-discovers these common report locations:
+
+- `coverage.xml`
+- `**/coverage.xml`
+- `cobertura.xml`
+- `**/cobertura.xml`
+- `lcov.info`
+- `**/lcov.info`
+- `coverage/lcov.info`
+- `**/coverage/lcov.info`
+- `.coverage-reports/**/*.xml`
+- `.coverage-reports/**/*.info`
+
+Usage notes:
+
+- Pull requests from forks usually do not receive repository secrets. In that case, the workflow logs a skip instead of failing.
+- Pushes to `main` fail if coverage files exist but no Codacy token is configured, so missing secret setup is visible immediately.
+- This repository's default CI currently does not generate coverage reports on its own. The Codacy workflow uploads reports that are produced by your test/build steps.
 
 ### Mirror Issue Labels — maintenance notes
 


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow to discover coverage reports and upload them to Codacy on pull requests and pushes to `main`
- Skip uploads safely for pull requests without available Codacy secrets, and fail `main` uploads when coverage exists but tokens are missing
- Document Codacy token setup, supported report locations, and current usage notes in the README
- Fixes #109

## Testing
- Not run (not requested)