### PR TITLE
Potential fix for code scanning alert no. 21: Uncontrolled data used in path expression

### DIFF
--- a/apps/status-api/server.py
+++ b/apps/status-api/server.py
@@ -473,7 +473,11 @@ def api_emergency_audio_delete():
     if ext not in ALLOWED_AUDIO_EXTENSIONS:
         return jsonify({"error": "Invalid file type"}), 400
 
-    filepath = os.path.join(EMERGENCY_AUDIO_DIR, filename)
+    base_dir = os.path.realpath(EMERGENCY_AUDIO_DIR)
+    filepath = os.path.realpath(os.path.join(base_dir, filename))
+    if os.path.commonpath([base_dir, filepath]) != base_dir:
+        return jsonify({"error": "Invalid filename"}), 400
+
     if not os.path.exists(filepath):
         return jsonify({"error": "File not found"}), 404
 


### PR DESCRIPTION
Potential fix for [https://github.com/sonicverse-eu/audiostreaming-stack/security/code-scanning/21](https://github.com/sonicverse-eu/audiostreaming-stack/security/code-scanning/21)

Use a safe-path containment check after normalization/canonicalization, and only proceed when the resolved path stays within `EMERGENCY_AUDIO_DIR`.

Best fix in this snippet:
1. Keep existing filename/extension validation (to preserve behavior).
2. Build `base_dir = os.path.realpath(EMERGENCY_AUDIO_DIR)`.
3. Build `filepath = os.path.realpath(os.path.join(base_dir, filename))`.
4. Enforce containment with `os.path.commonpath([base_dir, filepath]) == base_dir`; reject otherwise.
5. Continue with exists/remove logic.

This is the most robust minimal change in `apps/status-api/server.py` around lines 476–480, and it does not require new imports or dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
