### PR TITLE
fix: require POST for internal alert webhooks

### DIFF
--- a/apps/status-api/server.py
+++ b/apps/status-api/server.py
@@ -291,7 +291,7 @@ def api_auth_config():
     })
 
 
-@app.route("/api/alert", methods=["POST", "GET"])
+@app.route("/api/alert", methods=["POST"])
 def api_alert():
     """Receive alerts from the analytics service or Liquidsoap (internal only).
     Only accepts requests from Docker internal network (non-routable IPs)."""
@@ -302,8 +302,22 @@ def api_alert():
         return Response(json.dumps({"error": "Forbidden"}), 403,
                         {"Content-Type": "application/json"})
 
-    alert_type = request.args.get("type", "unknown")
-    message = request.args.get("message", "")
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        payload = {}
+
+    alert_type = (
+        payload.get("type")
+        or request.form.get("type")
+        or request.args.get("type")
+        or "unknown"
+    )
+    message = (
+        payload.get("message")
+        or request.form.get("message")
+        or request.args.get("message")
+        or ""
+    )
 
     alert = {
         "type": alert_type,

--- a/services/analytics/tracker.py
+++ b/services/analytics/tracker.py
@@ -5,6 +5,7 @@ Polls Icecast stats endpoint and sends listener metrics to PostHog.
 Receives silence detection webhooks from Liquidsoap and sends Pushover alerts.
 """
 
+import json
 import os
 import sys
 import threading
@@ -218,14 +219,42 @@ def handle_alert(alert_type):
 # ============================================================
 
 class AlertHandler(BaseHTTPRequestHandler):
+    def parse_alert_type(self):
+        parsed = urlparse(self.path)
+        if parsed.path != "/alert":
+            return None
+
+        params = parse_qs(parsed.query)
+        alert_type = params.get("type", [""])[0]
+        if alert_type:
+            return alert_type
+
+        length = int(self.headers.get("Content-Length", "0") or 0)
+        body = self.rfile.read(length) if length > 0 else b""
+        if not body:
+            return "unknown"
+
+        content_type = self.headers.get("Content-Type", "")
+        if "application/json" in content_type:
+            try:
+                payload = json.loads(body.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return "unknown"
+            if isinstance(payload, dict):
+                return str(payload.get("type", "unknown"))
+            return "unknown"
+
+        try:
+            params = parse_qs(body.decode("utf-8"))
+        except UnicodeDecodeError:
+            return "unknown"
+        return params.get("type", ["unknown"])[0]
+
     def do_GET(self):
         parsed = urlparse(self.path)
         if parsed.path == "/alert":
-            params = parse_qs(parsed.query)
-            alert_type = params.get("type", ["unknown"])[0]
-            print(f"[alerts] Received alert: {alert_type}")
-            handle_alert(alert_type)
-            self.send_response(200)
+            self.send_response(405)
+            self.send_header("Allow", "POST")
             self.end_headers()
         elif parsed.path == "/health":
             self.send_response(200)
@@ -233,6 +262,18 @@ class AlertHandler(BaseHTTPRequestHandler):
         else:
             self.send_response(404)
             self.end_headers()
+
+    def do_POST(self):
+        alert_type = self.parse_alert_type()
+        if alert_type is None:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        print(f"[alerts] Received alert: {alert_type}")
+        handle_alert(alert_type)
+        self.send_response(200)
+        self.end_headers()
 
     def log_message(self, format, *args):
         pass  # Suppress default request logging

--- a/services/streaming/liquidsoap/radio.liq
+++ b/services/streaming/liquidsoap/radio.liq
@@ -29,12 +29,12 @@ primary = input.harbor(
 
 primary.on_connect(synchronous=false, fun (_) -> begin
   log("OK: Primary harbor connected")
-  ignore(process.run("wget -q -O /dev/null 'http://analytics:8888/alert?type=harbor_primary_up'"))
+  ignore(process.run("wget -q -O /dev/null --post-data='type=harbor_primary_up' 'http://analytics:8888/alert'"))
 end)
 
 primary.on_disconnect(synchronous=false, fun () -> begin
   log("ALERT: Primary harbor disconnected")
-  ignore(process.run("wget -q -O /dev/null 'http://analytics:8888/alert?type=harbor_primary_down'"))
+  ignore(process.run("wget -q -O /dev/null --post-data='type=harbor_primary_down' 'http://analytics:8888/alert'"))
 end)
 
 # Fallback: lower bitrate Ogg stream
@@ -48,12 +48,12 @@ secondary = input.harbor(
 
 secondary.on_connect(synchronous=false, fun (_) -> begin
   log("OK: Secondary harbor connected")
-  ignore(process.run("wget -q -O /dev/null 'http://analytics:8888/alert?type=harbor_secondary_up'"))
+  ignore(process.run("wget -q -O /dev/null --post-data='type=harbor_secondary_up' 'http://analytics:8888/alert'"))
 end)
 
 secondary.on_disconnect(synchronous=false, fun () -> begin
   log("ALERT: Secondary harbor disconnected")
-  ignore(process.run("wget -q -O /dev/null 'http://analytics:8888/alert?type=harbor_secondary_down'"))
+  ignore(process.run("wget -q -O /dev/null --post-data='type=harbor_secondary_down' 'http://analytics:8888/alert'"))
 end)
 
 # --- Emergency fallback ---
@@ -91,12 +91,12 @@ radio = blank.detect(
 
 radio.on_blank(synchronous=false, fun () -> begin
   log("ALERT: Silence detected for #{silence_duration}s (threshold: #{silence_threshold}dB)")
-  ignore(process.run("wget -q -O /dev/null 'http://analytics:8888/alert?type=silence_start'"))
+  ignore(process.run("wget -q -O /dev/null --post-data='type=silence_start' 'http://analytics:8888/alert'"))
 end)
 
 radio.on_noise(synchronous=false, fun () -> begin
   log("OK: Audio resumed after silence")
-  ignore(process.run("wget -q -O /dev/null 'http://analytics:8888/alert?type=silence_end'"))
+  ignore(process.run("wget -q -O /dev/null --post-data='type=silence_end' 'http://analytics:8888/alert'"))
 end)
 
 # --- Icecast outputs (multiple bitrates/formats) ---


### PR DESCRIPTION
## Summary
- Switch internal alert webhook handling from `GET` to `POST` for state-changing requests
- Update the status API alert endpoint to accept `POST` only while still parsing JSON, form, or query inputs defensively
- Update the analytics webhook server to reject `GET /alert` with `405` and process alert types from `POST` bodies
- Update Liquidsoap webhook calls to send alert events with `POST`
- Fixes #TODO

## Testing
- Not run (not requested)