### PR TITLE
Fix Let's Encrypt nginx bootstrap conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Or for both local build and development dependencies:
    ```bash
    ./init-letsencrypt.sh
    ```
+   This script reuses the main `nginx` service when it is already running, or starts a temporary ACME-only nginx container for the HTTP challenge when the stack is not up yet. That temporary bootstrap container avoids name collisions with any existing `sonicverse-nginx` container during first-time certificate provisioning.
 
 4. **Start the stack**
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,15 @@ services:
       - streaming
     restart: unless-stopped
 
+  nginx-acme:
+    image: nginx:1.28.3-alpine-slim
+    profiles: ["acme-bootstrap"]
+    ports:
+      - "80:80"
+    volumes:
+      - ./certbot/www:/var/www/certbot:ro
+      - ./infrastructure/nginx/acme-bootstrap.conf:/etc/nginx/conf.d/default.conf:ro
+
   certbot:
     image: certbot/certbot
     container_name: sonicverse-certbot

--- a/infrastructure/nginx/acme-bootstrap.conf
+++ b/infrastructure/nginx/acme-bootstrap.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name _;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        try_files $uri =404;
+    }
+
+    location = /healthz {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    location / {
+        default_type text/plain;
+        return 200 "ACME bootstrap nginx\n";
+    }
+}

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
 
-# Obtain initial Let's Encrypt certificate for the streaming stack.
-# Run this once before starting the full stack.
+# Obtain an initial Let's Encrypt certificate for the streaming stack.
+# If the main nginx service is already running, reuse it for the ACME challenge.
+# Otherwise start a temporary ACME-only nginx container that does not depend on
+# the fixed sonicverse-nginx container name.
 #
 # Usage: ./init-letsencrypt.sh
 #
 # Requires: .env file with ICECAST_HOSTNAME and LETSENCRYPT_EMAIL set.
 
 set -e
+
+BOOTSTRAP_NGINX_STARTED=0
+MAIN_NGINX_WAS_RUNNING=0
+
+cleanup_bootstrap_nginx() {
+    if [[ "$BOOTSTRAP_NGINX_STARTED" == "1" ]]; then
+        docker compose --profile acme-bootstrap rm -fsv nginx-acme >/dev/null 2>&1 || true
+    fi
+}
+
+trap cleanup_bootstrap_nginx EXIT INT TERM
 
 # Load .env
 if [[ -f .env ]]; then
@@ -37,16 +50,16 @@ fi
 EMAIL="${LETSENCRYPT_EMAIL:-}"
 STAGING="${LETSENCRYPT_STAGING:-0}"
 
-EMAIL_ARG=""
+EMAIL_ARGS=()
 if [[ -n "$EMAIL" ]]; then
-    EMAIL_ARG="--email $EMAIL"
+    EMAIL_ARGS=(--email "$EMAIL")
 else
-    EMAIL_ARG="--register-unsafely-without-email"
+    EMAIL_ARGS=(--register-unsafely-without-email)
 fi
 
-STAGING_ARG=""
+STAGING_ARGS=()
 if [[ "$STAGING" == "1" ]]; then
-    STAGING_ARG="--staging"
+    STAGING_ARGS=(--staging)
     echo "Using Let's Encrypt staging environment (test certificates)"
 fi
 
@@ -55,14 +68,33 @@ echo "Requesting certificate for: $ICECAST_HOSTNAME"
 # Create required directories
 mkdir -p certbot/conf certbot/www
 
-# Nginx entrypoint auto-detects missing certs and runs HTTP-only mode.
-# No self-signed cert needed.
-echo "Starting nginx (HTTP-only mode for ACME challenge)..."
-docker compose up -d --no-deps nginx
+RUNNING_SERVICES="$(docker compose ps --status running --services 2>/dev/null || true)"
+if printf '%s\n' "$RUNNING_SERVICES" | grep -qx "nginx"; then
+    MAIN_NGINX_WAS_RUNNING=1
+    echo "Main nginx service is already running; reusing it for the ACME challenge."
+else
+    echo "Starting temporary ACME-only nginx service..."
+    if ! docker compose --profile acme-bootstrap up -d --no-deps nginx-acme; then
+        echo "Error: failed to start temporary nginx-acme service for the ACME challenge."
+        exit 1
+    fi
+    BOOTSTRAP_NGINX_STARTED=1
 
-# Wait for nginx to be ready
-echo "Waiting for nginx..."
-sleep 3
+    echo "Waiting for temporary nginx-acme to be ready..."
+    ready=0
+    for _ in {1..15}; do
+        if curl -fsS "http://127.0.0.1/healthz" >/dev/null 2>&1; then
+            ready=1
+            break
+        fi
+        sleep 1
+    done
+
+    if [[ "$ready" != "1" ]]; then
+        echo "Error: temporary nginx-acme did not become ready on http://127.0.0.1/healthz"
+        exit 1
+    fi
+fi
 
 echo "Requesting Let's Encrypt certificate..."
 # Override entrypoint since docker-compose.yml sets a renewal-loop entrypoint
@@ -70,16 +102,24 @@ docker compose run --rm --entrypoint "" certbot \
     certbot certonly \
     --webroot \
     --webroot-path=/var/www/certbot \
-    $EMAIL_ARG \
-    $STAGING_ARG \
+    "${EMAIL_ARGS[@]}" \
+    "${STAGING_ARGS[@]}" \
     --agree-tos \
     --no-eff-email \
     -d "$ICECAST_HOSTNAME"
 
-# Restart nginx so it picks up the real cert and enables HTTPS
-echo "Restarting nginx with SSL enabled..."
-docker compose restart nginx
+cleanup_bootstrap_nginx
+BOOTSTRAP_NGINX_STARTED=0
+
+if [[ "$MAIN_NGINX_WAS_RUNNING" == "1" ]]; then
+    echo "Restarting nginx with SSL enabled..."
+    docker compose restart nginx
+fi
 
 echo ""
 echo "Done! Certificate obtained for $ICECAST_HOSTNAME"
-echo "Start the full stack with: docker compose up -d"
+if [[ "$MAIN_NGINX_WAS_RUNNING" == "1" ]]; then
+    echo "Nginx was restarted and is now serving the new certificate."
+else
+    echo "Start the full stack with: docker compose up -d"
+fi


### PR DESCRIPTION
## Summary

- Add a profile-gated `nginx-acme` service and minimal config so ACME bootstrap can bind port 80 without reusing the fixed `sonicverse-nginx` container name.
- Update `init-letsencrypt.sh` to reuse a running main nginx when available, otherwise start, health-check, and clean up the temporary ACME nginx container, then restart main nginx only if it was already running.
- Document the new certificate bootstrap flow in `README.md`. Verified with `bash -n init-letsencrypt.sh`; `docker compose config` and `yamllint` were not available in this environment.

## Related GitHub issue

None.



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

