### PR TITLE
Fix nginx startup and optional status panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 # OPTIONAL (recommended for production):
 #   - PUSHOVER_* — alert notifications
 #   - POSTHOG_* — analytics
-#   - APPWRITE_* — operator panel authentication
+#   - APPWRITE_* / STATUS_PANEL_* — optional dashboard access
 #
 # Auto-generated during setup (./install.sh):
 #   - ICECAST_RELAY_PASSWORD, ICECAST_SOURCE_PASSWORD, HARBOR_PASSWORD, etc.
@@ -64,16 +64,20 @@ PUSHOVER_USER_KEY=
 PUSHOVER_APP_TOKEN=
 
 # ============================================================
-# Appwrite — Status panel authentication (OPTIONAL)
+# Appwrite / status dashboard (OPTIONAL)
 # ============================================================
+# Set to 1 to run the optional status API in Docker and expose /api/ through nginx.
+ENABLE_STATUS_PANEL=0
+
 # Required only if you want to use the interactive status panel
-APPWRITE_ENDPOINT=https://cloud.appwrite.io/v1
+# Recommended endpoint: https://cloud.appwrite.io/v1
+APPWRITE_ENDPOINT=
 APPWRITE_PROJECT_ID=
 # Required when APPWRITE_PROJECT_ID is set (panel access is team-scoped).
 APPWRITE_TEAM_ID=
 
-# Status panel frontend URL (for CORS)
-STATUS_PANEL_CORS_ORIGIN=https://status.example.com
+# Status panel frontend URL(s) for CORS, comma-separated
+STATUS_PANEL_CORS_ORIGIN=
 STATUS_PANEL_HOST=127.0.0.1
 
 # Comma-separated list of roles that can write/modify via panel

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Docker Hub](https://img.shields.io/badge/Images-Docker%20Hub-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/u/sonicverse)
 [![Join Sonicverse OSS Slack](https://img.shields.io/badge/Join-Sonicverse%20OSS%20Slack-4A154B?logo=slack&logoColor=white)](https://join.slack.com/t/sonicverse-oss/shared_invite/zt-3u969i5rr-cmfgEycFAi8V7Baj0uBx0A)
 
-Self-hosted Docker Compose stack for live radio streaming. Ingest from any studio encoder, deliver via Icecast2 and HLS adaptive bitrate, with automatic fallback, silence detection, PostHog analytics, Pushover alerts, and a real-time operator dashboard.
+Self-hosted Docker Compose stack for live radio streaming. Ingest from any studio encoder, deliver via Icecast2 and HLS adaptive bitrate, with automatic fallback, silence detection, PostHog analytics, Pushover alerts, and an optional real-time operator dashboard.
 
 ## Documentation
 
@@ -52,7 +52,7 @@ Studio (BUTT/etc)
 | **Icecast2** | Stream distribution server with multiple mount points |
 | **Liquidsoap** | Stream processor — ingest, fallback chain, encoding, HLS |
 | **Nginx** | Public-facing reverse proxy + HLS segment serving |
-| **Status Panel** | Flask API backend — stream health, container status, emergency audio management |
+| **Status Panel** | Optional Flask API backend for the operator dashboard and service management |
 | **Analytics** | Polls Icecast stats and sends events to PostHog + Pushover alerts |
 | **Certbot** | Automatic Let's Encrypt certificate renewal |
 
@@ -361,10 +361,11 @@ All settings are managed via `.env` (copy from `.env.example`):
 | `PUSHOVER_APP_TOKEN` | Pushover application token |
 | `SILENCE_THRESHOLD_DB` | Silence detection threshold in dB (default: `-40`) |
 | `SILENCE_DURATION` | Seconds of silence before alerting (default: `15`) |
-| `APPWRITE_ENDPOINT` | Appwrite API endpoint |
-| `APPWRITE_PROJECT_ID` | Appwrite project ID |
-| `APPWRITE_TEAM_ID` | Appwrite team ID (required when `APPWRITE_PROJECT_ID` is set; only members get panel access) |
-| `STATUS_PANEL_CORS_ORIGIN` | Status dashboard URL(s) for CORS, comma-separated (e.g. `https://status.example.com`) |
+| `ENABLE_STATUS_PANEL` | Set to `1` to run the optional status API and expose `/api/` through nginx |
+| `APPWRITE_ENDPOINT` | Optional Appwrite API endpoint for dashboard auth |
+| `APPWRITE_PROJECT_ID` | Optional Appwrite project ID |
+| `APPWRITE_TEAM_ID` | Optional Appwrite team ID (required when `APPWRITE_PROJECT_ID` is set; only members get panel access) |
+| `STATUS_PANEL_CORS_ORIGIN` | Optional dashboard URL(s) for CORS, comma-separated |
 | `STATUS_PANEL_HOST` | Optional bind host for status API (default: `127.0.0.1`; auto-uses container IP in Docker when unset) |
 | `STATUS_PANEL_WRITE_ROLES` | Appwrite team roles allowed to manage emergency audio (default: `owner,admin`) |
 | `STATUS_PANEL_ALLOW_RISKY_COMMANDS` | Enable remote restart/SSL renewal commands (`0` by default) |
@@ -374,7 +375,13 @@ All settings are managed via `.env` (copy from `.env.example`):
 
 ## Status Panel
 
-Real-time broadcast engineer dashboard with Appwrite team-based authentication.
+Optional real-time broadcast engineer dashboard with Appwrite team-based authentication.
+
+Set `ENABLE_STATUS_PANEL=1` to include the Docker `status-api` service. If you manage the stack manually instead of using `./install.sh`, start it with:
+
+```bash
+docker compose --profile status-panel up -d
+```
 
 **Features:**
 - Live listener counts and mount point status (5s refresh)

--- a/apps/status-api/server.py
+++ b/apps/status-api/server.py
@@ -1,9 +1,9 @@
 """
 Sonicverse Status Panel — API backend
 
-Serves a real-time dashboard showing stream health, listener counts,
-source status, alert history, configuration, and container status.
-Protected by Appwrite authentication.
+Serves an optional real-time dashboard showing stream health, listener
+counts, source status, alert history, configuration, and container status.
+Can be protected by Appwrite authentication.
 """
 
 import functools
@@ -26,7 +26,7 @@ from werkzeug.exceptions import RequestEntityTooLarge
 app = Flask(__name__)
 app.config["MAX_CONTENT_LENGTH"] = 1024 * 1024 * 1024  # 1 GiB upload limit
 
-# CORS — set STATUS_PANEL_CORS_ORIGIN in your .env to your status dashboard URL(s), comma-separated.
+# CORS — set STATUS_PANEL_CORS_ORIGIN only when you expose the dashboard frontend.
 def get_cors_origins():
     raw_origins = os.getenv("STATUS_PANEL_CORS_ORIGIN", "")
     origins = {origin.strip() for origin in raw_origins.split(",") if origin.strip()}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - ICECAST_HOSTNAME=${ICECAST_HOSTNAME}
       - STATION_NAME=${STATION_NAME:-Radio Station}
       - STATION_ADMIN_EMAIL=${STATION_ADMIN_EMAIL:-admin@example.com}
+      - ENABLE_STATUS_PANEL=${ENABLE_STATUS_PANEL:-0}
     volumes:
       - hls-data:/hls:ro
       - ./certbot/conf:/etc/letsencrypt:ro
@@ -93,6 +94,7 @@ services:
     build: ./apps/status-api
     image: docker.io/sonicverse/audiostreaming-stack-status-api:latest
     container_name: sonicverse-status-api
+    profiles: ["status-panel"]
     depends_on:
       icecast:
         condition: service_healthy

--- a/infrastructure/nginx/Dockerfile
+++ b/infrastructure/nginx/Dockerfile
@@ -6,7 +6,13 @@ COPY nginx.conf /etc/nginx/nginx.conf.template
 COPY index.html.template /etc/nginx/index.html.template
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
-RUN adduser -D -u 1000 appuser && chown -R 1000:1000 /etc/nginx/nginx.conf.template /etc/nginx/index.html.template /docker-entrypoint.sh
+RUN adduser -D -u 1000 appuser \
+    && mkdir -p /usr/share/nginx/html /var/cache/nginx \
+    && chown -R 1000:1000 \
+        /etc/nginx \
+        /usr/share/nginx/html \
+        /var/cache/nginx \
+        /docker-entrypoint.sh
 USER 1000
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/infrastructure/nginx/docker-entrypoint.sh
+++ b/infrastructure/nginx/docker-entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 HOSTNAME="${ICECAST_HOSTNAME:-localhost}"
 CERT_PATH="/etc/letsencrypt/live/$HOSTNAME/fullchain.pem"
+STATUS_PANEL_ENABLED="${ENABLE_STATUS_PANEL:-0}"
 
 # Substitute only our custom variable, leave nginx variables ($host etc.) alone
 envsubst '$ICECAST_HOSTNAME' < /etc/nginx/nginx.conf.template > /tmp/nginx-substituted.conf
@@ -29,6 +30,11 @@ else
     echo "[nginx] No SSL certificate found — serving HTTP only (for ACME challenge)"
     # Strip the HTTPS server block, keep only HTTP
     sed '/# HTTPS_START/,/# HTTPS_END/d' /tmp/nginx-substituted.conf > /etc/nginx/nginx.conf
+fi
+
+if [ "$STATUS_PANEL_ENABLED" != "1" ]; then
+    echo "[nginx] Status panel API disabled — removing /api routes"
+    sed -i '/# STATUS_API_START/,/# STATUS_API_END/d' /etc/nginx/nginx.conf
 fi
 
 rm -f /tmp/nginx-substituted.conf

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -1,4 +1,5 @@
 worker_processes auto;
+pid /tmp/nginx.pid;
 
 events {
     worker_connections 1024;
@@ -10,6 +11,11 @@ http {
     sendfile      on;
     keepalive_timeout 65;
     client_max_body_size 1g;
+    client_body_temp_path /tmp/nginx-client-body;
+    proxy_temp_path /tmp/nginx-proxy;
+    fastcgi_temp_path /tmp/nginx-fastcgi;
+    uwsgi_temp_path /tmp/nginx-uwsgi;
+    scgi_temp_path /tmp/nginx-scgi;
 
     # CORS for /api/ routes is handled by Flask-CORS in the status-api container.
 
@@ -58,10 +64,12 @@ http {
             add_header X-Robots-Tag "noindex, nofollow" always;
         }
 
+        # STATUS_API_START
         # Sensitive operator endpoints are HTTPS-only.
         location /api/ {
             return 308 https://$host$request_uri;
         }
+        # STATUS_API_END
 
         location /icecast-admin/ {
             return 308 https://$host$request_uri;
@@ -117,6 +125,7 @@ http {
             add_header X-Robots-Tag "noindex, nofollow" always;
         }
 
+        # STATUS_API_START
         # Internal alert ingestion endpoint (restricted before proxying)
         location = /api/alert {
             allow 127.0.0.1;
@@ -143,6 +152,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Internal-Alert "";
         }
+        # STATUS_API_END
 
         # Icecast admin panel
         location /icecast-admin/ {

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -13,6 +13,8 @@ set -e
 
 BOOTSTRAP_NGINX_STARTED=0
 MAIN_NGINX_WAS_RUNNING=0
+CERTBOT_SERVICE_RUNNING=0
+ENABLE_STATUS_PANEL="${ENABLE_STATUS_PANEL:-0}"
 
 cleanup_bootstrap_nginx() {
     if [[ "$BOOTSTRAP_NGINX_STARTED" == "1" ]]; then
@@ -20,7 +22,29 @@ cleanup_bootstrap_nginx() {
     fi
 }
 
+remove_conflicting_named_container() {
+    local service="$1"
+    local fixed_name="sonicverse-$service"
+    local current_id existing_id
+
+    current_id="$(docker compose ps -q "$service" 2>/dev/null | head -n 1)"
+    existing_id="$(docker ps -aq --filter "name=^/${fixed_name}$" 2>/dev/null | head -n 1)"
+
+    if [[ -n "$existing_id" && "$existing_id" != "$current_id" ]]; then
+        echo "Removing conflicting container: $fixed_name"
+        docker rm -f "$existing_id" >/dev/null
+    fi
+}
+
 trap cleanup_bootstrap_nginx EXIT INT TERM
+
+compose_up_command() {
+    if [[ "$ENABLE_STATUS_PANEL" == "1" ]]; then
+        echo "docker compose --profile status-panel up -d"
+    else
+        echo "docker compose up -d"
+    fi
+}
 
 # Load .env
 if [[ -f .env ]]; then
@@ -96,17 +120,42 @@ else
     fi
 fi
 
+if printf '%s\n' "$RUNNING_SERVICES" | grep -qx "certbot"; then
+    CERTBOT_SERVICE_RUNNING=1
+else
+    CERTBOT_CONTAINER_ID="$(docker compose ps -q certbot 2>/dev/null | head -n 1)"
+    if [[ -n "$CERTBOT_CONTAINER_ID" ]]; then
+        echo "Starting existing certbot service for certificate issuance..."
+        docker compose up -d certbot >/dev/null
+        CERTBOT_SERVICE_RUNNING=1
+    else
+        remove_conflicting_named_container "certbot"
+    fi
+fi
+
 echo "Requesting Let's Encrypt certificate..."
-# Override entrypoint since docker-compose.yml sets a renewal-loop entrypoint
-docker compose run --rm --entrypoint "" certbot \
-    certbot certonly \
-    --webroot \
-    --webroot-path=/var/www/certbot \
-    "${EMAIL_ARGS[@]}" \
-    "${STAGING_ARGS[@]}" \
-    --agree-tos \
-    --no-eff-email \
-    -d "$ICECAST_HOSTNAME"
+if [[ "$CERTBOT_SERVICE_RUNNING" == "1" ]]; then
+    docker compose exec -T certbot \
+        certbot certonly \
+        --webroot \
+        --webroot-path=/var/www/certbot \
+        "${EMAIL_ARGS[@]}" \
+        "${STAGING_ARGS[@]}" \
+        --agree-tos \
+        --no-eff-email \
+        -d "$ICECAST_HOSTNAME"
+else
+    # Override entrypoint since docker-compose.yml sets a renewal-loop entrypoint.
+    docker compose run --rm --no-deps --entrypoint "" certbot \
+        certbot certonly \
+        --webroot \
+        --webroot-path=/var/www/certbot \
+        "${EMAIL_ARGS[@]}" \
+        "${STAGING_ARGS[@]}" \
+        --agree-tos \
+        --no-eff-email \
+        -d "$ICECAST_HOSTNAME"
+fi
 
 cleanup_bootstrap_nginx
 BOOTSTRAP_NGINX_STARTED=0
@@ -121,5 +170,5 @@ echo "Done! Certificate obtained for $ICECAST_HOSTNAME"
 if [[ "$MAIN_NGINX_WAS_RUNNING" == "1" ]]; then
     echo "Nginx was restarted and is now serving the new certificate."
 else
-    echo "Start the full stack with: docker compose up -d"
+    echo "Start the full stack with: $(compose_up_command)"
 fi

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,66 @@ warn()    { echo -e "  ${YELLOW}!${NC}  $1"; }
 error()   { echo -e "  ${RED}✗${NC}  $1"; }
 step()    { echo -e "\n${BOLD}[$1/$TOTAL_STEPS] $2${NC}"; }
 
+COMPOSE_PROFILE_ARGS=()
+
+refresh_compose_profile_args() {
+    local enabled="${ENABLE_STATUS_PANEL:-}"
+
+    if [[ -z "$enabled" && -f .env ]]; then
+        enabled="$(grep '^ENABLE_STATUS_PANEL=' .env 2>/dev/null | tail -n 1 | cut -d= -f2-)"
+    fi
+
+    if [[ "$enabled" == "1" ]]; then
+        COMPOSE_PROFILE_ARGS=(--profile status-panel)
+    else
+        COMPOSE_PROFILE_ARGS=()
+    fi
+}
+
+docker_compose() {
+    refresh_compose_profile_args
+    docker compose "${COMPOSE_PROFILE_ARGS[@]}" "$@"
+}
+
+compose_up_command() {
+    refresh_compose_profile_args
+    if [[ "${#COMPOSE_PROFILE_ARGS[@]}" -gt 0 ]]; then
+        echo "docker compose --profile status-panel up -d"
+    else
+        echo "docker compose up -d"
+    fi
+}
+
+compose_down_command() {
+    refresh_compose_profile_args
+    if [[ "${#COMPOSE_PROFILE_ARGS[@]}" -gt 0 ]]; then
+        echo "docker compose --profile status-panel down"
+    else
+        echo "docker compose down"
+    fi
+}
+
+remove_conflicting_named_container() {
+    local service="$1"
+    local fixed_name="sonicverse-$service"
+    local current_id existing_id
+
+    current_id="$(docker_compose ps -q "$service" 2>/dev/null | head -n 1)"
+    existing_id="$(docker ps -aq --filter "name=^/${fixed_name}$" 2>/dev/null | head -n 1)"
+
+    if [[ -n "$existing_id" && "$existing_id" != "$current_id" ]]; then
+        warn "Removing conflicting container ${fixed_name}"
+        docker rm -f "$existing_id" >/dev/null
+    fi
+}
+
+clear_conflicting_stack_container_names() {
+    local service
+    for service in icecast liquidsoap nginx certbot status-api analytics; do
+        remove_conflicting_named_container "$service"
+    done
+}
+
 prompt() {
     local var_name="$1" prompt_text="$2" default="$3"
     if [[ -n "$default" ]]; then
@@ -171,7 +231,7 @@ fi
 # ----------------------------------------------------------
 # Detect existing installation
 # ----------------------------------------------------------
-if docker compose ps --quiet 2>/dev/null | head -1 | grep -q .; then
+if docker_compose ps --quiet 2>/dev/null | head -1 | grep -q .; then
     echo ""
     warn "Existing streaming stack detected!"
     echo ""
@@ -191,8 +251,8 @@ if docker compose ps --quiet 2>/dev/null | head -1 | grep -q .; then
 
             info "Backing up currently running service images..."
             backup_count=0
-            for service in $(docker compose config --services 2>/dev/null || true); do
-                container_id="$(docker compose ps -q "$service" 2>/dev/null || true)"
+            for service in $(docker_compose config --services 2>/dev/null || true); do
+                container_id="$(docker_compose ps -q "$service" 2>/dev/null || true)"
                 if [[ -z "$container_id" ]]; then
                     continue
                 fi
@@ -215,13 +275,14 @@ if docker compose ps --quiet 2>/dev/null | head -1 | grep -q .; then
             git pull 2>/dev/null || true
             echo ""
             info "Pulling latest images..."
-            docker compose pull || true
+            docker_compose pull || true
             echo ""
             info "Rebuilding any local images..."
-            docker compose build
+            docker_compose build
             echo ""
             info "Applying updates with zero downtime..."
-            if ! docker compose up -d --remove-orphans; then
+            clear_conflicting_stack_container_names
+            if ! docker_compose up -d --remove-orphans; then
                 error "Failed to update stack. Rolling back..."
                 if [[ -s "$backup_file" ]]; then
                     info "Restoring previously running images..."
@@ -233,19 +294,20 @@ if docker compose ps --quiet 2>/dev/null | head -1 | grep -q .; then
                 else
                     warn "No image backups found; retrying with current images."
                 fi
-                docker compose up -d --remove-orphans || true
+                clear_conflicting_stack_container_names
+                docker_compose up -d --remove-orphans || true
                 exit 1
             fi
             echo ""
             success "Stack updated successfully!"
             echo ""
-            docker compose ps
+            docker_compose ps
             echo ""
             exit 0
             ;;
         2)
             info "Stopping and removing existing stack..."
-            docker compose down --rmi local --remove-orphans
+            docker_compose down --rmi local --remove-orphans
             docker volume rm audiostreaming-stack_hls-data audiostreaming-stack_icecast-logs 2>/dev/null || true
             success "Old stack removed"
             echo ""
@@ -260,11 +322,11 @@ if docker compose ps --quiet 2>/dev/null | head -1 | grep -q .; then
             exit 1
             ;;
     esac
-elif docker compose ps -a --quiet 2>/dev/null | head -1 | grep -q .; then
+elif docker_compose ps -a --quiet 2>/dev/null | head -1 | grep -q .; then
     warn "Stopped containers from a previous install detected."
     read -rp "  → Remove them before continuing? (Y/n): " remove_old
     if [[ ! "$remove_old" =~ ^[Nn]$ ]]; then
-        docker compose down --rmi local --remove-orphans
+        docker_compose down --rmi local --remove-orphans
         success "Old containers removed"
     fi
 fi
@@ -387,23 +449,35 @@ if [[ "${SKIP_ENV}" != "true" ]]; then
     prompt PUSHOVER_USER_KEY  "Pushover user key (leave empty to skip alerts)" ""
     prompt PUSHOVER_APP_TOKEN "Pushover app token" ""
 
-    # Appwrite (status panel auth)
+    # Optional status dashboard
     echo ""
-    prompt APPWRITE_ENDPOINT   "Appwrite endpoint" "https://cloud.appwrite.io/v1"
-    prompt APPWRITE_PROJECT_ID "Appwrite project ID" ""
-    prompt APPWRITE_TEAM_ID    "Appwrite team ID (members get panel access)" ""
-    if [[ -n "${APPWRITE_PROJECT_ID}" && -z "${APPWRITE_TEAM_ID}" ]]; then
-        warn "APPWRITE_TEAM_ID is required when APPWRITE_PROJECT_ID is set."
-        while [[ -z "${APPWRITE_TEAM_ID}" ]]; do
-            prompt APPWRITE_TEAM_ID "Appwrite team ID (required for panel access)" ""
-            if [[ -z "${APPWRITE_TEAM_ID}" ]]; then
-                warn "Team ID cannot be empty while Appwrite panel auth is enabled."
-            fi
-        done
+    read -rp "  → Enable the optional status dashboard API now? (y/N): " configure_status_dashboard
+    if [[ "$configure_status_dashboard" =~ ^[Yy]$ ]]; then
+        ENABLE_STATUS_PANEL="1"
+        prompt APPWRITE_ENDPOINT   "Appwrite endpoint" "https://cloud.appwrite.io/v1"
+        prompt APPWRITE_PROJECT_ID "Appwrite project ID" ""
+        prompt APPWRITE_TEAM_ID    "Appwrite team ID (members get panel access)" ""
+        if [[ -n "${APPWRITE_PROJECT_ID}" && -z "${APPWRITE_TEAM_ID}" ]]; then
+            warn "APPWRITE_TEAM_ID is required when APPWRITE_PROJECT_ID is set."
+            while [[ -z "${APPWRITE_TEAM_ID}" ]]; do
+                prompt APPWRITE_TEAM_ID "Appwrite team ID (required for panel access)" ""
+                if [[ -z "${APPWRITE_TEAM_ID}" ]]; then
+                    warn "Team ID cannot be empty while Appwrite panel auth is enabled."
+                fi
+            done
+        fi
+        prompt STATUS_PANEL_CORS_ORIGIN "Status panel frontend URL(s) for CORS" ""
+        prompt STATUS_PANEL_WRITE_ROLES "Operator roles for writes (comma-separated)" "owner,admin"
+        prompt STATUS_PANEL_ALLOW_RISKY_COMMANDS "Allow destructive panel commands? (0/1)" "0"
+    else
+        ENABLE_STATUS_PANEL="0"
+        APPWRITE_ENDPOINT=""
+        APPWRITE_PROJECT_ID=""
+        APPWRITE_TEAM_ID=""
+        STATUS_PANEL_CORS_ORIGIN=""
+        STATUS_PANEL_WRITE_ROLES="owner,admin"
+        STATUS_PANEL_ALLOW_RISKY_COMMANDS="0"
     fi
-    prompt STATUS_PANEL_CORS_ORIGIN "Status panel frontend URL(s) for CORS" "https://status.example.com"
-    prompt STATUS_PANEL_WRITE_ROLES "Operator roles for writes (comma-separated)" "owner,admin"
-    prompt STATUS_PANEL_ALLOW_RISKY_COMMANDS "Allow destructive panel commands? (0/1)" "0"
 
     # PostHog
     echo ""
@@ -447,6 +521,7 @@ SILENCE_THRESHOLD_DB=-40
 SILENCE_DURATION=15
 
 # Appwrite (status panel auth)
+ENABLE_STATUS_PANEL=${ENABLE_STATUS_PANEL}
 APPWRITE_ENDPOINT=${APPWRITE_ENDPOINT}
 APPWRITE_PROJECT_ID=${APPWRITE_PROJECT_ID}
 APPWRITE_TEAM_ID=${APPWRITE_TEAM_ID}
@@ -514,13 +589,13 @@ step "$STEP_NUM" "Building containers"
 if [[ "$USE_PREBUILT" == "true" ]]; then
     info "Pulling pre-built images from Docker Hub or configured registry..."
     echo ""
-    docker compose pull || { error "Pull failed. Images may not exist yet. Run with --build-local to build locally instead."; exit 1; }
+    docker_compose pull || { error "Pull failed. Images may not exist yet. Run with --build-local to build locally instead."; exit 1; }
     echo ""
     success "All images pulled successfully"
 else
     info "Building containers locally. This may take a few minutes on first run..."
     echo ""
-    docker compose build
+    docker_compose build
     echo ""
     success "All containers built successfully"
 fi
@@ -578,11 +653,12 @@ step "$STEP_NUM" "Launch"
 echo ""
 read -rp "  → Start the streaming stack now? (Y/n): " start_now
 if [[ ! "$start_now" =~ ^[Nn]$ ]]; then
-    docker compose up -d
+    clear_conflicting_stack_container_names
+    docker_compose up -d
     echo ""
     success "Streaming stack is running!"
 else
-    info "Start later with: docker compose up -d"
+    info "Start later with: $(compose_up_command)"
 fi
 
 # ----------------------------------------------------------
@@ -611,6 +687,11 @@ echo ""
 echo -e "  ${BOLD}Useful commands:${NC}"
 echo "    docker compose logs -f          # Follow all logs"
 echo "    docker compose logs liquidsoap  # Liquidsoap logs only"
+if [[ "${ENABLE_STATUS_PANEL:-0}" == "1" ]]; then
+echo "    docker compose --profile status-panel restart  # Restart all services"
+echo "    docker compose --profile status-panel down     # Stop everything"
+else
 echo "    docker compose restart           # Restart all services"
 echo "    docker compose down              # Stop everything"
+fi
 echo ""


### PR DESCRIPTION
## Summary

- Fix the non-root nginx image so it can render its landing page and write runtime pid/temp files.
- Prevent certbot bootstrap and installer runs from failing on stale fixed-name containers.
- Make the status dashboard API opt-in with `ENABLE_STATUS_PANEL`, remove nginx `/api/` routes when disabled, and document the new flow.

## Related GitHub issue

N/A




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

