### PR TITLE
Fix nginx temp paths and certbot reload flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Studio (BUTT/etc)
 | **Nginx** | Public-facing reverse proxy + HLS segment serving |
 | **Status Panel** | Optional Flask API backend for the operator dashboard and service management |
 | **Analytics** | Polls Icecast stats and sends events to PostHog + Pushover alerts |
-| **Certbot** | Automatic Let's Encrypt certificate renewal |
+| **Certbot** | Automatic Let's Encrypt certificate renewal with nginx reload signaling |
 
 ## Repository Structure
 

--- a/apps/status-api/server.py
+++ b/apps/status-api/server.py
@@ -644,7 +644,14 @@ def run_restart_stack(_):
 
 
 def run_renew_ssl(_):
-    exit_code, output = get_service_container("certbot").exec_run(["certbot", "renew"])
+    exit_code, output = get_service_container("certbot").exec_run(
+        [
+            "certbot",
+            "renew",
+            "--deploy-hook",
+            'printf "%s\\n" "$(date -u +%s)" > /etc/letsencrypt/.nginx-reload',
+        ]
+    )
     return output.decode("utf-8", errors="replace").strip() or "(no output)", exit_code
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,15 @@ services:
     volumes:
       - ./certbot/conf:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        trap exit TERM
+        while :; do
+          certbot renew --quiet --deploy-hook 'printf "%s\n" "$(date -u +%s)" > /etc/letsencrypt/.nginx-reload'
+          sleep 12h & wait $${!}
+        done
     networks:
       - streaming
     restart: unless-stopped

--- a/infrastructure/nginx/Dockerfile
+++ b/infrastructure/nginx/Dockerfile
@@ -7,11 +7,20 @@ COPY index.html.template /etc/nginx/index.html.template
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN adduser -D -u 1000 appuser \
-    && mkdir -p /usr/share/nginx/html /var/cache/nginx \
+    && mkdir -p \
+        /usr/share/nginx/html \
+        /var/cache/nginx/client_temp \
+        /var/cache/nginx/proxy_temp \
+        /var/cache/nginx/fastcgi_temp \
+        /var/cache/nginx/uwsgi_temp \
+        /var/cache/nginx/scgi_temp \
+        /var/run/nginx \
+        /etc/nginx/rendered \
     && chown -R 1000:1000 \
         /etc/nginx \
         /usr/share/nginx/html \
         /var/cache/nginx \
+        /var/run/nginx \
         /docker-entrypoint.sh
 USER 1000
 

--- a/infrastructure/nginx/docker-entrypoint.sh
+++ b/infrastructure/nginx/docker-entrypoint.sh
@@ -3,10 +3,14 @@ set -e
 
 HOSTNAME="${ICECAST_HOSTNAME:-localhost}"
 CERT_PATH="/etc/letsencrypt/live/$HOSTNAME/fullchain.pem"
+KEY_PATH="/etc/letsencrypt/live/$HOSTNAME/privkey.pem"
 STATUS_PANEL_ENABLED="${ENABLE_STATUS_PANEL:-0}"
+RENDERED_CONFIG_PATH="/etc/nginx/rendered/nginx.conf"
+FINAL_CONFIG_PATH="/etc/nginx/nginx.conf"
+RELOAD_MARKER="/etc/letsencrypt/.nginx-reload"
 
 # Substitute only our custom variable, leave nginx variables ($host etc.) alone
-envsubst '$ICECAST_HOSTNAME' < /etc/nginx/nginx.conf.template > /tmp/nginx-substituted.conf
+envsubst '$ICECAST_HOSTNAME' < /etc/nginx/nginx.conf.template > "$RENDERED_CONFIG_PATH"
 
 # Substitute template for root index HTML with custom variables
 mkdir -p /usr/share/nginx/html
@@ -23,19 +27,45 @@ export STATION_ADMIN_EMAIL_ESC="$(escape_html "$FINAL_CONTACT_EMAIL")"
 
 envsubst '$STATION_NAME_ESC $STATION_ADMIN_EMAIL_ESC $ICECAST_HOSTNAME' < /etc/nginx/index.html.template > /usr/share/nginx/html/index.html
 
-if [ -f "$CERT_PATH" ]; then
-    echo "[nginx] SSL certificate found for $HOSTNAME — enabling HTTPS"
-    cp /tmp/nginx-substituted.conf /etc/nginx/nginx.conf
-else
-    echo "[nginx] No SSL certificate found — serving HTTP only (for ACME challenge)"
-    # Strip the HTTPS server block, keep only HTTP
-    sed '/# HTTPS_START/,/# HTTPS_END/d' /tmp/nginx-substituted.conf > /etc/nginx/nginx.conf
-fi
+write_nginx_config() {
+    if [ -f "$CERT_PATH" ] && [ -f "$KEY_PATH" ]; then
+        echo "[nginx] SSL certificate found for $HOSTNAME — enabling HTTPS"
+        cp "$RENDERED_CONFIG_PATH" "$FINAL_CONFIG_PATH"
+    else
+        echo "[nginx] No SSL certificate found — serving HTTP only (for ACME challenge)"
+        sed '/# HTTPS_START/,/# HTTPS_END/d' "$RENDERED_CONFIG_PATH" > "$FINAL_CONFIG_PATH"
+    fi
 
-if [ "$STATUS_PANEL_ENABLED" != "1" ]; then
-    echo "[nginx] Status panel API disabled — removing /api routes"
-    sed -i '/# STATUS_API_START/,/# STATUS_API_END/d' /etc/nginx/nginx.conf
-fi
+    if [ "$STATUS_PANEL_ENABLED" != "1" ]; then
+        echo "[nginx] Status panel API disabled — removing /api routes"
+        sed -i '/# STATUS_API_START/,/# STATUS_API_END/d' "$FINAL_CONFIG_PATH"
+    fi
+}
 
-rm -f /tmp/nginx-substituted.conf
+marker_value() {
+    if [ -f "$RELOAD_MARKER" ]; then
+        cat "$RELOAD_MARKER" 2>/dev/null || echo 0
+    else
+        echo 0
+    fi
+}
+
+watch_certificate_updates() {
+    last_marker="$(marker_value)"
+
+    while :; do
+        sleep 30
+        current_marker="$(marker_value)"
+
+        if [ "$current_marker" != "$last_marker" ]; then
+            last_marker="$current_marker"
+            echo "[nginx] Certificate update detected — reloading nginx"
+            write_nginx_config
+            nginx -s reload
+        fi
+    done
+}
+
+write_nginx_config
+watch_certificate_updates &
 exec nginx -g 'daemon off;'

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -1,5 +1,5 @@
 worker_processes auto;
-pid /tmp/nginx.pid;
+pid /var/run/nginx/nginx.pid;
 
 events {
     worker_connections 1024;
@@ -11,11 +11,11 @@ http {
     sendfile      on;
     keepalive_timeout 65;
     client_max_body_size 1g;
-    client_body_temp_path /tmp/nginx-client-body;
-    proxy_temp_path /tmp/nginx-proxy;
-    fastcgi_temp_path /tmp/nginx-fastcgi;
-    uwsgi_temp_path /tmp/nginx-uwsgi;
-    scgi_temp_path /tmp/nginx-scgi;
+    client_body_temp_path /var/cache/nginx/client_temp;
+    proxy_temp_path /var/cache/nginx/proxy_temp;
+    fastcgi_temp_path /var/cache/nginx/fastcgi_temp;
+    uwsgi_temp_path /var/cache/nginx/uwsgi_temp;
+    scgi_temp_path /var/cache/nginx/scgi_temp;
 
     # CORS for /api/ routes is handled by Flask-CORS in the status-api container.
 

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -87,6 +87,8 @@ if [[ "$STAGING" == "1" ]]; then
     echo "Using Let's Encrypt staging environment (test certificates)"
 fi
 
+DEPLOY_HOOK='printf "%s\n" "$(date -u +%s)" > /etc/letsencrypt/.nginx-reload'
+
 echo "Requesting certificate for: $ICECAST_HOSTNAME"
 
 # Create required directories
@@ -139,6 +141,7 @@ if [[ "$CERTBOT_SERVICE_RUNNING" == "1" ]]; then
         certbot certonly \
         --webroot \
         --webroot-path=/var/www/certbot \
+        --deploy-hook "$DEPLOY_HOOK" \
         "${EMAIL_ARGS[@]}" \
         "${STAGING_ARGS[@]}" \
         --agree-tos \
@@ -150,6 +153,7 @@ else
         certbot certonly \
         --webroot \
         --webroot-path=/var/www/certbot \
+        --deploy-hook "$DEPLOY_HOOK" \
         "${EMAIL_ARGS[@]}" \
         "${STAGING_ARGS[@]}" \
         --agree-tos \

--- a/install.sh
+++ b/install.sh
@@ -32,21 +32,23 @@ else
     # Define minimal info/error for remote setup
     _info() { echo -e "  ${BLUE}ℹ${NC}  $1"; }
     _error() { echo -e "  ${RED}✗${NC}  $1"; }
-    
-    # Create a temporary directory for the clone
-    WORK_DIR="/tmp/audiostreaming-stack-$(date +%s)"
+
+    # Clone into a cache directory so the installer does not depend on the system temp area.
+    INSTALL_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/audiostreaming-stack-installer"
+    WORK_DIR="${INSTALL_CACHE_DIR}/clone-$(date +%s)-$$"
+    mkdir -p "$INSTALL_CACHE_DIR"
     mkdir -p "$WORK_DIR"
-    
+
     _info "Cloning audiostreaming-stack to $WORK_DIR"
-    
+
     # Clone the repository with shallow clone for speed
     if ! git clone --depth 1 https://github.com/sonicverse-eu/audiostreaming-stack.git "$WORK_DIR" 2>/dev/null; then
         _error "Failed to clone repository. Ensure git is installed and you have internet connectivity."
         exit 1
     fi
-    
+
     _info "Starting installer from cloned repository..."
-    
+
     # Execute the script from within the cloned directory
     cd "$WORK_DIR"
     bash ./install.sh "$@"


### PR DESCRIPTION
## Summary
- Remove `/tmp` usage from the installer and nginx runtime paths
- Move nginx temp/cache files to writable in-container locations
- Make certbot renewals trigger an nginx reload signal so new certs take effect
- Update the status API and README to match the new renewal behavior

## Testing
- Shell syntax checks passed for the touched shell scripts
- `ruff check` passed for the Python services
- `hadolint` passed for the nginx Dockerfile
- `yamllint` reported existing long-line warnings in `.github/workflows/docker-build-push.yml`
- Compose validation was not completed in this environment because `docker compose`/`docker-compose` were unavailable