### PR TITLE
Add .env file support and enhance certbot directory setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build: ./services/streaming/icecast
     image: docker.io/sonicverse/audiostreaming-stack-icecast:latest
     container_name: sonicverse-icecast
+    env_file:
+      - .env
     environment:
       - STATION_LOCATION=${STATION_LOCATION:-Netherlands}
       - STATION_ADMIN_EMAIL=${STATION_ADMIN_EMAIL:-admin@example.com}
@@ -27,6 +29,8 @@ services:
     build: ./services/streaming/liquidsoap
     image: docker.io/sonicverse/audiostreaming-stack-liquidsoap:latest
     container_name: sonicverse-liquidsoap
+    env_file:
+      - .env
     depends_on:
       icecast:
         condition: service_healthy
@@ -51,6 +55,8 @@ services:
     build: ./infrastructure/nginx
     image: docker.io/sonicverse/audiostreaming-stack-nginx:latest
     container_name: sonicverse-nginx
+    env_file:
+      - .env
     depends_on:
       - icecast
       - liquidsoap
@@ -82,6 +88,8 @@ services:
   certbot:
     image: certbot/certbot
     container_name: sonicverse-certbot
+    env_file:
+      - .env
     volumes:
       - ./certbot/conf:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot
@@ -93,17 +101,13 @@ services:
       - -c
       - |
         set -e
-        HOSTNAME="${ICECAST_HOSTNAME:-}"
+        HOSTNAME="${ICECAST_HOSTNAME:?ICECAST_HOSTNAME must be set}"
         EMAIL="${STATION_ADMIN_EMAIL:-admin@example.com}"
 
-        if [ -z "$HOSTNAME" ]; then
-          echo "certbot: ICECAST_HOSTNAME not set; skipping initial issuance"
-        else
-          if [ ! -d "/etc/letsencrypt/live/$HOSTNAME" ]; then
-            echo "certbot: No cert for $HOSTNAME — attempting initial issuance"
-            certbot certonly --non-interactive --agree-tos --email "$EMAIL" --webroot -w /var/www/certbot -d "$HOSTNAME" || echo "Initial issuance failed"
-            printf "%s\n" "$(date -u +%s)" > /etc/letsencrypt/.nginx-reload || true
-          fi
+        if [ ! -d "/etc/letsencrypt/live/$HOSTNAME" ]; then
+          echo "certbot: No cert for $HOSTNAME — attempting initial issuance"
+          certbot certonly --non-interactive --agree-tos --email "$EMAIL" --webroot -w /var/www/certbot -d "$HOSTNAME" || echo "Initial issuance failed"
+          printf "%s\n" "$(date -u +%s)" > /etc/letsencrypt/.nginx-reload || true
         fi
 
         trap exit TERM
@@ -122,6 +126,8 @@ services:
     image: docker.io/sonicverse/audiostreaming-stack-status-api:latest
     container_name: sonicverse-status-api
     profiles: ["status-panel"]
+    env_file:
+      - .env
     depends_on:
       icecast:
         condition: service_healthy
@@ -154,6 +160,8 @@ services:
     build: ./services/analytics
     image: docker.io/sonicverse/audiostreaming-stack-analytics:latest
     container_name: sonicverse-analytics
+    env_file:
+      - .env
     depends_on:
       icecast:
         condition: service_healthy

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -46,6 +46,30 @@ compose_up_command() {
     fi
 }
 
+setup_certbot_directory() {
+    local target_dir="$(pwd)"
+    local cache_dir=""
+
+    if [[ -d "$XDG_CACHE_HOME/audiostreaming-stack-installer" ]]; then
+        cache_dir="$XDG_CACHE_HOME/audiostreaming-stack-installer"
+    elif [[ -d "$HOME/.cache/audiostreaming-stack-installer" ]]; then
+        cache_dir="$HOME/.cache/audiostreaming-stack-installer"
+    fi
+
+    if [[ -n "$cache_dir" && -d "$cache_dir" ]]; then
+        local latest_clone
+        latest_clone="$(ls -td "$cache_dir"/clone-* 2>/dev/null | head -1)"
+        if [[ -n "$latest_clone" && -d "$latest_clone/certbot" && "$latest_clone" != "$target_dir" ]]; then
+            if [[ ! -d "$target_dir/certbot" ]]; then
+                ln -s "$latest_clone/certbot" "$target_dir/certbot"
+                echo "Linked certbot directory from $latest_clone"
+            fi
+        fi
+    fi
+}
+
+setup_certbot_directory
+
 # Load .env
 if [[ -f .env ]]; then
     export $(grep -v '^#' .env | xargs)

--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,20 @@ refresh_compose_profile_args() {
 
 docker_compose() {
     refresh_compose_profile_args
+
+    CERTBOT_LINKED=0
+    if [[ -d "$XDG_CACHE_HOME/audiostreaming-stack-installer" || -d "$HOME/.cache/audiostreaming-stack-installer" ]]; then
+        local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/audiostreaming-stack-installer"
+        local latest_clone
+        latest_clone="$(ls -td "$cache_dir"/clone-* 2>/dev/null | head -1)"
+        if [[ -n "$latest_clone" && -d "$latest_clone/certbot" && ! -L "$(pwd)/certbot" ]]; then
+            if [[ ! -d "certbot" ]]; then
+                ln -s "$latest_clone/certbot" ./certbot
+                CERTBOT_LINKED=1
+            fi
+        fi
+    fi
+
     docker compose "${COMPOSE_PROFILE_ARGS[@]}" "$@"
 }
 


### PR DESCRIPTION
## Summary

Enhance service configurations by adding support for a `.env` file to manage environment variables. Improve the setup of the certbot directory by linking it from a cache if available, ensuring a more streamlined deployment process.

## Related GitHub issue

Closes #

