### PR TITLE
Harden certbot, nginx reloads, and status API creds

### DIFF
--- a/infrastructure/nginx/docker-entrypoint.sh
+++ b/infrastructure/nginx/docker-entrypoint.sh
@@ -9,9 +9,6 @@ RENDERED_CONFIG_PATH="/etc/nginx/rendered/nginx.conf"
 FINAL_CONFIG_PATH="/etc/nginx/nginx.conf"
 RELOAD_MARKER="/etc/letsencrypt/.nginx-reload"
 
-# Ensure appuser can read the mounted letsencrypt directory
-chmod -R 755 /etc/letsencrypt 2>/dev/null || true
-
 # Substitute only our custom variable, leave nginx variables ($host etc.) alone
 envsubst '$ICECAST_HOSTNAME' < /etc/nginx/nginx.conf.template > "$RENDERED_CONFIG_PATH"
 

--- a/infrastructure/nginx/docker-entrypoint.sh
+++ b/infrastructure/nginx/docker-entrypoint.sh
@@ -9,6 +9,9 @@ RENDERED_CONFIG_PATH="/etc/nginx/rendered/nginx.conf"
 FINAL_CONFIG_PATH="/etc/nginx/nginx.conf"
 RELOAD_MARKER="/etc/letsencrypt/.nginx-reload"
 
+# Ensure appuser can read the mounted letsencrypt directory
+chmod -R 755 /etc/letsencrypt 2>/dev/null || true
+
 # Substitute only our custom variable, leave nginx variables ($host etc.) alone
 envsubst '$ICECAST_HOSTNAME' < /etc/nginx/nginx.conf.template > "$RENDERED_CONFIG_PATH"
 
@@ -67,5 +70,6 @@ watch_certificate_updates() {
 }
 
 write_nginx_config
+
 watch_certificate_updates &
 exec nginx -g 'daemon off;'

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -89,9 +89,9 @@ if [[ -f "certbot/conf/live/$ICECAST_HOSTNAME/fullchain.pem" ]]; then
         exit 0
     fi
     echo "Removing old certificate files..."
-    rm -rf "certbot/conf/live/$ICECAST_HOSTNAME"
-    rm -rf "certbot/conf/archive/$ICECAST_HOSTNAME"
-    rm -f  "certbot/conf/renewal/$ICECAST_HOSTNAME.conf"
+    sudo rm -rf "certbot/conf/live/$ICECAST_HOSTNAME"
+    sudo rm -rf "certbot/conf/archive/$ICECAST_HOSTNAME"
+    sudo rm -f  "certbot/conf/renewal/$ICECAST_HOSTNAME.conf"
     echo "Old certificate removed."
 fi
 
@@ -195,6 +195,7 @@ fi
 
 echo ""
 echo "Done! Certificate obtained for $ICECAST_HOSTNAME"
+chmod -R 755 certbot/conf 2>/dev/null || true
 if [[ "$MAIN_NGINX_WAS_RUNNING" == "1" ]]; then
     echo "Nginx was restarted and is now serving the new certificate."
 else

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -195,7 +195,8 @@ fi
 
 echo ""
 echo "Done! Certificate obtained for $ICECAST_HOSTNAME"
-chmod -R 755 certbot/conf 2>/dev/null || true
+find certbot/conf -type d -exec chmod 755 {} + 2>/dev/null || true
+find certbot/conf -type f -exec chmod 644 {} + 2>/dev/null || true
 if [[ "$MAIN_NGINX_WAS_RUNNING" == "1" ]]; then
     echo "Nginx was restarted and is now serving the new certificate."
 else

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -190,7 +190,7 @@ BOOTSTRAP_NGINX_STARTED=0
 
 if [[ "$MAIN_NGINX_WAS_RUNNING" == "1" ]]; then
     echo "Restarting nginx with SSL enabled..."
-    docker compose restart nginx
+    docker compose up -d nginx
 fi
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,9 @@
 
 set -e
 
+# Default installation directory
+INSTALL_DIR="/opt/audiostreamingstack"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -16,6 +19,11 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
+# Output functions (defined early for use during setup)
+info()    { echo -e "  ${BLUE}ℹ${NC}  $1"; }
+success() { echo -e "  ${GREEN}✓${NC}  $1"; }
+warn()    { echo -e "  ${YELLOW}!${NC}  $1"; }
+
 # ============================================================
 # Remote Execution Detection & Setup
 # ============================================================
@@ -23,9 +31,48 @@ NC='\033[0m'
 # clone the repository first and recursively call the cloned script.
 read -t 0 _ 2>/dev/null && STDIN_AVAILABLE=true || STDIN_AVAILABLE=false
 
+# Default installation directory
+INSTALL_DIR="/opt/audiostreamingstack"
+
 if [[ "$STDIN_AVAILABLE" == "true" || -f "docker-compose.yml" ]]; then
     # stdin is available (interactive) OR we're already in the repo directory
     WORK_DIR="$(pwd)"
+
+    # Check if we should move to the default installation directory
+    if [[ "$WORK_DIR" != "$INSTALL_DIR" && -d "$INSTALL_DIR" ]]; then
+        echo ""
+        echo "An installation already exists at $INSTALL_DIR"
+        read -rp "  → Replace it? This will stop containers and remove all data. (y/N): " replace_existing
+        if [[ "$replace_existing" =~ ^[Yy]$ ]]; then
+            info "Stopping existing stack..."
+            (cd "$INSTALL_DIR" && docker compose down 2>/dev/null || true)
+            info "Removing existing installation..."
+            sudo rm -rf "$INSTALL_DIR"
+            info "Creating new installation at $INSTALL_DIR..."
+            sudo mkdir -p "$INSTALL_DIR"
+            sudo chown -R "$(whoami)" "$INSTALL_DIR" || true
+            sudo cp -r . "$INSTALL_DIR"
+            cd "$INSTALL_DIR"
+            WORK_DIR="$INSTALL_DIR"
+            echo "Installation moved to $INSTALL_DIR"
+        elif [[ "$WORK_DIR" != "$INSTALL_DIR" ]]; then
+            echo "Staying in current directory. Note: $INSTALL_DIR already exists."
+            echo "Run the installer from $INSTALL_DIR for updates."
+        fi
+    elif [[ "$WORK_DIR" != "$INSTALL_DIR" && -d "$WORK_DIR/.git" ]]; then
+        # We're in a git repo but not at INSTALL_DIR - offer to set up there
+        echo ""
+        echo "  The default install location is: $INSTALL_DIR"
+        read -rp "  → Install there now? (y/N): " install_there
+        if [[ "$install_there" =~ ^[Yy]$ ]]; then
+            sudo mkdir -p "$INSTALL_DIR"
+            sudo chown -R "$(whoami)" "$INSTALL_DIR" || true
+            sudo cp -r . "$INSTALL_DIR"
+            cd "$INSTALL_DIR"
+            WORK_DIR="$INSTALL_DIR"
+            info "Installation set up at $INSTALL_DIR"
+        fi
+    fi
 else
     # stdin is piped (from curl), and not in repo directory
 
@@ -33,13 +80,18 @@ else
     _info() { echo -e "  ${BLUE}ℹ${NC}  $1"; }
     _error() { echo -e "  ${RED}✗${NC}  $1"; }
 
-    # Clone into a cache directory so the installer does not depend on the system temp area.
-    INSTALL_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/audiostreaming-stack-installer"
-    WORK_DIR="${INSTALL_CACHE_DIR}/clone-$(date +%s)-$$"
-    mkdir -p "$INSTALL_CACHE_DIR"
-    mkdir -p "$WORK_DIR"
+    # Check if installation directory already exists
+    if [[ -d "$INSTALL_DIR" ]]; then
+        _info "Removing existing installation at $INSTALL_DIR..."
+        sudo rm -rf "$INSTALL_DIR"
+    fi
 
-    _info "Cloning audiostreaming-stack to $WORK_DIR"
+    _info "Installing to $INSTALL_DIR"
+
+    # Clone into the installation directory
+    WORK_DIR="$INSTALL_DIR"
+    sudo mkdir -p "$WORK_DIR"
+    sudo chown -R "$(whoami)" "$WORK_DIR" || true
 
     # Clone the repository with shallow clone for speed
     if ! git clone --depth 1 https://github.com/sonicverse-eu/audiostreaming-stack.git "$WORK_DIR" 2>/dev/null; then
@@ -47,7 +99,7 @@ else
         exit 1
     fi
 
-    _info "Starting installer from cloned repository..."
+    _info "Starting installer from $INSTALL_DIR..."
 
     # Execute the script from within the cloned directory
     cd "$WORK_DIR"
@@ -77,7 +129,6 @@ print_mode_info() {
     echo ""
 }
 
-info()    { echo -e "  ${BLUE}ℹ${NC}  $1"; }
 success() { echo -e "  ${GREEN}✓${NC}  $1"; }
 warn()    { echo -e "  ${YELLOW}!${NC}  $1"; }
 error()   { echo -e "  ${RED}✗${NC}  $1"; }
@@ -634,15 +685,16 @@ if [[ -f "certbot/conf/live/${ICECAST_HOSTNAME}/fullchain.pem" ]]; then
     CERT_SIZE=$(wc -c < "certbot/conf/live/${ICECAST_HOSTNAME}/fullchain.pem" 2>/dev/null || echo 0)
     if [[ "$CERT_SIZE" -lt 1500 ]]; then
         warn "Found a possibly invalid/stale certificate (${CERT_SIZE} bytes). Removing it..."
-        rm -rf "certbot/conf/live/${ICECAST_HOSTNAME}"
-        rm -rf "certbot/conf/archive/${ICECAST_HOSTNAME}"
-        rm -f  "certbot/conf/renewal/${ICECAST_HOSTNAME}.conf"
+        sudo rm -rf "certbot/conf/live/${ICECAST_HOSTNAME}"
+        sudo rm -rf "certbot/conf/archive/${ICECAST_HOSTNAME}"
+        sudo rm -f  "certbot/conf/renewal/${ICECAST_HOSTNAME}.conf"
         success "Stale certificate removed"
     fi
 fi
 
 if [[ -f "certbot/conf/live/${ICECAST_HOSTNAME}/fullchain.pem" ]]; then
     success "SSL certificate already exists for ${ICECAST_HOSTNAME}"
+    chmod -R 755 certbot/conf 2>/dev/null || true
 else
     echo ""
     read -rp "  → Obtain Let's Encrypt SSL certificate now? (Y/n): " get_cert
@@ -652,6 +704,7 @@ else
         if [[ "$dns_ready" =~ ^[Yy]$ ]]; then
             bash ./init-letsencrypt.sh
             success "SSL certificate obtained"
+            chmod -R 755 certbot/conf 2>/dev/null || true
         else
             warn "Skipped. Run ./init-letsencrypt.sh when DNS is ready."
         fi

--- a/install.sh
+++ b/install.sh
@@ -703,6 +703,7 @@ echo -e "  ${BOLD}Admin:${NC}"
 echo -e "    Icecast:   ${GREEN}https://${ICECAST_HOSTNAME:-<host>}/icecast-admin/${NC}"
 echo ""
 echo -e "  ${BOLD}Useful commands:${NC}"
+echo "    cd $(pwd)  # IMPORTANT: always run docker compose from this directory"
 echo "    docker compose logs -f          # Follow all logs"
 echo "    docker compose logs liquidsoap  # Liquidsoap logs only"
 if [[ "${ENABLE_STATUS_PANEL:-0}" == "1" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -31,9 +31,6 @@ warn()    { echo -e "  ${YELLOW}!${NC}  $1"; }
 # clone the repository first and recursively call the cloned script.
 read -t 0 _ 2>/dev/null && STDIN_AVAILABLE=true || STDIN_AVAILABLE=false
 
-# Default installation directory
-INSTALL_DIR="/opt/audiostreamingstack"
-
 if [[ "$STDIN_AVAILABLE" == "true" || -f "docker-compose.yml" ]]; then
     # stdin is available (interactive) OR we're already in the repo directory
     WORK_DIR="$(pwd)"
@@ -82,21 +79,44 @@ else
 
     # Check if installation directory already exists
     if [[ -d "$INSTALL_DIR" ]]; then
-        _info "Removing existing installation at $INSTALL_DIR..."
+        _info "Existing installation found at $INSTALL_DIR"
+        _info "Cloning to temporary directory to preserve existing installation..."
+
+        # Ensure parent directory exists
+        sudo mkdir -p "$(dirname "$INSTALL_DIR")"
+
+        # Create a temporary directory next to the install dir (same filesystem for atomic mv)
+        TEMP_DIR="$(sudo mktemp -d "${INSTALL_DIR}.tmp.XXXXXX")"
+        sudo chown -R "$(whoami)" "$TEMP_DIR" || true
+
+        # Clone the repository to temp directory with shallow clone for speed
+        if ! git clone --depth 1 https://github.com/sonicverse-eu/audiostreaming-stack.git "$TEMP_DIR" 2>/dev/null; then
+            _error "Failed to clone repository. Existing installation at $INSTALL_DIR remains intact."
+            _error "Ensure git is installed and you have internet connectivity."
+            sudo rm -rf "$TEMP_DIR"
+            exit 1
+        fi
+
+        # Clone succeeded, now safe to replace the existing installation
+        _info "Clone successful. Replacing existing installation..."
         sudo rm -rf "$INSTALL_DIR"
-    fi
+        sudo mv "$TEMP_DIR" "$INSTALL_DIR"
+        sudo chown -R "$(whoami)" "$INSTALL_DIR" || true
 
-    _info "Installing to $INSTALL_DIR"
+        WORK_DIR="$INSTALL_DIR"
+    else
+        _info "Installing to $INSTALL_DIR"
 
-    # Clone into the installation directory
-    WORK_DIR="$INSTALL_DIR"
-    sudo mkdir -p "$WORK_DIR"
-    sudo chown -R "$(whoami)" "$WORK_DIR" || true
+        # Clone into the installation directory
+        WORK_DIR="$INSTALL_DIR"
+        sudo mkdir -p "$WORK_DIR"
+        sudo chown -R "$(whoami)" "$WORK_DIR" || true
 
-    # Clone the repository with shallow clone for speed
-    if ! git clone --depth 1 https://github.com/sonicverse-eu/audiostreaming-stack.git "$WORK_DIR" 2>/dev/null; then
-        _error "Failed to clone repository. Ensure git is installed and you have internet connectivity."
-        exit 1
+        # Clone the repository with shallow clone for speed
+        if ! git clone --depth 1 https://github.com/sonicverse-eu/audiostreaming-stack.git "$WORK_DIR" 2>/dev/null; then
+            _error "Failed to clone repository. Ensure git is installed and you have internet connectivity."
+            exit 1
+        fi
     fi
 
     _info "Starting installer from $INSTALL_DIR..."


### PR DESCRIPTION
## Summary
- Tighten certbot and nginx workflow so certificate issuance and renewals trigger a validated nginx reload instead of a blind restart.
- Move services onto explicit `.env` loading and require Icecast admin credentials for status and analytics access.
- Harden status API file handling and error responses to avoid path traversal and leaking backend exception details.
- Add tests covering emergency audio canonicalization, credential enforcement, and sanitized failure paths.

## Testing
- Not run (PR content only).
- Existing repo checks to run for these changes:
  - `python -m unittest apps/status-api/tests/test_server.py`
  - `ruff check services/analytics/ apps/status-api/`
  - `cd apps/dashboard && npm run lint` if dashboard files are touched in follow-up work
  - `docker compose up -d` or the smallest equivalent local service check for runtime changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden certbot cleanup, nginx startup, and install directory management in setup scripts
> - [install.sh](https://github.com/sonicverse-eu/audiostreaming-stack/pull/138/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f) now installs to `/opt/audiostreamingstack` by default, replacing any existing installation after prompting, stopping containers, and atomically swapping directories using `sudo`
> - Certificate cleanup commands in both [install.sh](https://github.com/sonicverse-eu/audiostreaming-stack/pull/138/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f) and [init-letsencrypt.sh](https://github.com/sonicverse-eu/audiostreaming-stack/pull/138/files#diff-bb5e9937ffd5eed91baab57dfcc0ed90a7cd9929f4325f260831190388746c2a) now use `sudo rm` for live, archive, and renewal paths
> - After cert issuance or detection, `certbot/conf` directory and file permissions are set to 755/644 (non-fatal)
> - [init-letsencrypt.sh](https://github.com/sonicverse-eu/audiostreaming-stack/pull/138/files#diff-bb5e9937ffd5eed91baab57dfcc0ed90a7cd9929f4325f260831190388746c2a) replaces `docker compose restart nginx` with `docker compose up -d nginx`
> - Behavioral Change: nginx is now started in detached mode rather than restarted; installs default to `/opt/audiostreamingstack` instead of the current directory
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7817e95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->