### PR TITLE
docs: add early development warning to CONTRIBUTING, README, and SECURITY

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 Thank you for your interest in contributing. This document covers how to get started, submit changes, and report issues.
 
+> [!WARNING]
+> **Early Development — Not Production Ready.** This project is under active development. APIs, configuration, and behaviour may change without notice.
+
 Primary documentation lives at **https://docs.sonicverse.eu**. Use it as the canonical source for setup and operational guidance.
 
 Task tracking for this repository uses GitHub Issues. Prefer opening or linking a GitHub issue for bugs, feature work, and follow-up tasks so PRs stay connected to the active record of work.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![Docker Hub](https://img.shields.io/badge/Images-Docker%20Hub-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/u/sonicverse)
 [![Join Sonicverse OSS Slack](https://img.shields.io/badge/Join-Sonicverse%20OSS%20Slack-4A154B?logo=slack&logoColor=white)](https://join.slack.com/t/sonicverse-oss/shared_invite/zt-3u969i5rr-cmfgEycFAi8V7Baj0uBx0A)
 
+> [!WARNING]
+> **Early Development — Not Production Ready.** This project is under active development. APIs, configuration, and behaviour may change without notice. Do not use in production environments without thorough evaluation and testing.
+
 Self-hosted Docker Compose stack for live radio streaming. Ingest from any studio encoder, deliver via Icecast2 and HLS adaptive bitrate, with automatic fallback, silence detection, PostHog analytics, Pushover alerts, and an optional real-time operator dashboard.
 
 ## Documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,9 @@
 # Security Policy
 
+> [!WARNING]
+> **Early Development — Not Production Ready.** This project is under active development. APIs, configuration, and behaviour may change without notice. Do not use in production environments without thorough evaluation and testing.
+
 Primary project documentation is maintained at **https://docs.sonicverse.eu**. This file covers only security reporting expectations for this repository.
-
-## Supported Versions
-
-| Version | Supported |
-|---------|-----------|
-| Latest  | Yes       |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Adds a consistent "Early Development — Not Production Ready" warning notice
to the three top-level docs files so contributors and users know APIs,
config, and behaviour may change without notice.

- **CONTRIBUTING.md** — warning callout after the intro paragraph.
- **README.md** — warning callout above the project description, including
  a note not to use in production without thorough evaluation.
- **SECURITY.md** — same warning moved to the top; also drops the
  "Supported Versions" table (the project is too early to make support
  guarantees per version).

<!-- Primary documentation source: https://docs.sonicverse.eu -->

## Related GitHub issue

Closes #145 