### PR TITLE
refactor: migrate domain references from sonicverse.eu to sonicverse.tech

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: []
 
 <!-- A clear description of what is wrong. -->
 
-Reference the relevant docs page when possible: https://docs.sonicverse.eu
+Reference the relevant docs page when possible: https://docs.sonicverse.tech
 
 ## Steps to reproduce
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ assignees: []
 
 <!-- What are you trying to do that you currently cannot? -->
 
-Reference the related docs page when possible: https://docs.sonicverse.eu
+Reference the related docs page when possible: https://docs.sonicverse.tech
 
 ## Proposed solution
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 <!-- What does this PR change and why? -->
 
-<!-- Primary documentation source: https://docs.sonicverse.eu -->
+<!-- Primary documentation source: https://docs.sonicverse.tech -->
 
 ## Related GitHub issue
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 This repository accepts AI-assisted changes, but agents should follow the same standards as human contributors in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-Primary project documentation is maintained at **https://docs.sonicverse.eu** and should be treated as the source of truth for setup and operations.
-MCP documentation: **https://docs.sonicverse.eu/mcp**
+Primary project documentation is maintained at **https://docs.sonicverse.tech** and should be treated as the source of truth for setup and operations.
+MCP documentation: **https://docs.sonicverse.tech/mcp**
 
 Task tracking for this repository uses GitHub Issues. When work is tied to an issue, reference the GitHub issue number in branch names, commits, and pull requests where appropriate.
 

--- a/AI_PR_REVIEWER.md
+++ b/AI_PR_REVIEWER.md
@@ -65,7 +65,7 @@
 - Reference the related issue when one exists.
 - Update `README.md` when user-visible behavior or configuration changes.
 - Do not mix unrelated refactors into operational changes, especially across multiple services.
-- Changes to runtime behavior should stay consistent with the canonical docs at `https://docs.sonicverse.eu`.
+- Changes to runtime behavior should stay consistent with the canonical docs at `https://docs.sonicverse.tech`.
 
 ## Common Pitfalls
 
@@ -79,4 +79,4 @@
 
 - Ignore generated dependency trees and installed artifacts such as `node_modules`.
 - Do not request large architectural rewrites when a service-local fix is sufficient.
-- Do not treat external setup/operations docs as duplicative drift unless the PR actually changes repo behavior; `docs.sonicverse.eu` is the source of truth for ops guidance.
+- Do not treat external setup/operations docs as duplicative drift unless the PR actually changes repo behavior; `docs.sonicverse.tech` is the source of truth for ops guidance.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,7 +21,7 @@ Participants in this project are expected to:
 
 ## Reporting
 
-Report conduct issues to `oss@sonicverse.eu`.
+Report conduct issues to `oss@sonicverse.tech`.
 
 This inbox is maintained by `@rikvisser-dev` from Sonicverse.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing. This document covers how to get sta
 > [!WARNING]
 > **Early Development — Not Production Ready.** This project is under active development. APIs, configuration, and behaviour may change without notice.
 
-Primary documentation lives at **https://docs.sonicverse.eu**. Use it as the canonical source for setup and operational guidance.
+Primary documentation lives at **https://docs.sonicverse.tech**. Use it as the canonical source for setup and operational guidance.
 
 Task tracking for this repository uses GitHub Issues. Prefer opening or linking a GitHub issue for bugs, feature work, and follow-up tasks so PRs stay connected to the active record of work.
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Self-hosted Docker Compose stack for live radio streaming. Ingest from any studi
 
 For setup, operations, and troubleshooting, use the official Sonicverse docs as the single source of truth:
 
-**https://docs.sonicverse.eu**
+**https://docs.sonicverse.tech**
 
-This repository README is a quick project overview. If local instructions differ from the external docs, follow docs.sonicverse.eu.
+This repository README is a quick project overview. If local instructions differ from the external docs, follow docs.sonicverse.tech.
 
 Contributing to this project means following the [Code of Conduct](CODE_OF_CONDUCT.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > **Early Development — Not Production Ready.** This project is under active development. APIs, configuration, and behaviour may change without notice. Do not use in production environments without thorough evaluation and testing.
 
-Primary project documentation is maintained at **https://docs.sonicverse.eu**. This file covers only security reporting expectations for this repository.
+Primary project documentation is maintained at **https://docs.sonicverse.tech**. This file covers only security reporting expectations for this repository.
 
 ## Reporting a Vulnerability
 

--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
               </a>.
             </div>
             <div className="mt-2 sm:mt-0 flex items-center gap-4">
-              <a href="https://docs.sonicverse.eu" target="_blank" rel="noopener noreferrer" className="flex items-center gap-1.5 hover:text-white transition-colors">
+              <a href="https://docs.sonicverse.tech" target="_blank" rel="noopener noreferrer" className="flex items-center gap-1.5 hover:text-white transition-colors">
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path>
                   <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path>

--- a/docs/INSTALL_SHORT_URL_SETUP.md
+++ b/docs/INSTALL_SHORT_URL_SETUP.md
@@ -172,7 +172,7 @@ Enable optional analytics with:
 Once configured, update:
 
 1. **README.md** - Add quick install section
-2. **docs.sonicverse.eu** - Link to short URL
+2. **docs.sonicverse.tech** - Link to short URL
 3. **Presentation slides** - Use memorable short link
 4. **Chat/forums** - Easier sharing
 

--- a/infrastructure/nginx/index.html.template
+++ b/infrastructure/nginx/index.html.template
@@ -273,7 +273,7 @@
     <div class="footer">
         <div>&copy; <script>document.write(new Date().getFullYear())</script> <span style="font-weight: 600; color: var(--text-main);">Sonicverse</span>. Released under the <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener noreferrer">MIT License</a>.</div>
         <div class="footer-links">
-            <a href="https://docs.sonicverse.eu" target="_blank" rel="noopener noreferrer">
+            <a href="https://docs.sonicverse.tech" target="_blank" rel="noopener noreferrer">
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
                 Documentation
             </a>

--- a/install-redirect.html
+++ b/install-redirect.html
@@ -59,7 +59,7 @@
         <p><code>bash &lt;(curl -fsSL https://raw.githubusercontent.com/sonicverse-eu/audiostreaming-stack/main/install.sh)</code></p>
         <p><a href="https://github.com/sonicverse-eu/audiostreaming-stack">Back to repository</a></p>
         <p style="font-size: 12px; color: #999; margin-top: 30px;">
-            For setup details, see <a href="https://docs.sonicverse.eu" target="_blank">docs.sonicverse.eu</a>
+            For setup details, see <a href="https://docs.sonicverse.tech" target="_blank">docs.sonicverse.tech</a>
         </p>
     </div>
 </body>

--- a/install.sh
+++ b/install.sh
@@ -569,7 +569,7 @@ if [[ "${SKIP_ENV}" != "true" ]]; then
     # PostHog
     echo ""
     prompt POSTHOG_API_KEY  "PostHog API key (leave empty to skip analytics)" ""
-    prompt POSTHOG_HOST     "PostHog host" "https://posthog.sonicverse.eu"
+    prompt POSTHOG_HOST     "PostHog host" "https://posthog.sonicverse.tech"
     prompt POSTHOG_POLL_INTERVAL "Analytics poll interval (seconds)" "30"
 
     # Ports


### PR DESCRIPTION
## Summary

Replaces every `sonicverse.eu` reference with `sonicverse.tech` across the
repository so all docs links, contact addresses, and runtime defaults point
at the new domain. No behavioural changes beyond the URL/host swap.

**Docs & community files**
- `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `AGENTS.md`,
  `AI_PR_REVIEWER.md` — docs links updated to `docs.sonicverse.tech`
  (including the `/mcp` path in AGENTS.md).
- `CODE_OF_CONDUCT.md` — conduct contact updated to `oss@sonicverse.tech`.
- `.github/ISSUE_TEMPLATE/bug_report.md`,
  `.github/ISSUE_TEMPLATE/feature_request.md`,
  `.github/PULL_REQUEST_TEMPLATE.md` — docs references updated.
- `docs/INSTALL_SHORT_URL_SETUP.md` — docs reference updated.

**App & infrastructure**
- `apps/dashboard/app/layout.tsx` — docs footer link updated.
- `infrastructure/nginx/index.html.template`, `install-redirect.html` —
  documentation links updated.
- `install.sh` — default `POSTHOG_HOST` updated to
  `https://posthog.sonicverse.tech`.

<!-- Primary documentation source: https://docs.sonicverse.tech -->

## Related GitHub issue

Closes #146

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs a mechanical find-and-replace of every `sonicverse.eu` reference with `sonicverse.tech` across the entire repository. A grep of the post-merge tree confirms zero remaining `.eu` occurrences, so the migration is complete.

- **Docs & community files** (`README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `AGENTS.md`, `AI_PR_REVIEWER.md`, `CODE_OF_CONDUCT.md`, GitHub templates, `docs/INSTALL_SHORT_URL_SETUP.md`) — all documentation links and the conduct contact address updated to the new domain.
- **App & infrastructure** (`apps/dashboard/app/layout.tsx`, `infrastructure/nginx/index.html.template`, `install-redirect.html`) — footer and landing-page docs links updated.
- **`install.sh`** — the default `POSTHOG_HOST` prompt value updated to `https://posthog.sonicverse.tech`; only affects new installations that accept the default without overriding it.

<h3>Confidence Score: 5/5</h3>

Safe to merge — every change is a direct string substitution with no logic modifications.

All 14 files contain only URL/address substitutions. A full-repo grep confirms no sonicverse.eu strings remain. The single runtime-affecting change — the default PostHog host in install.sh — is clearly intentional and only influences new installs that accept the default value.

No files require special attention; all changes are straightforward domain string replacements.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| install.sh | Default POSTHOG_HOST prompt value updated from posthog.sonicverse.eu to posthog.sonicverse.tech; only affects new installations that accept the default. |
| apps/dashboard/app/layout.tsx | Footer docs link href updated to docs.sonicverse.tech; no logic changes. |
| infrastructure/nginx/index.html.template | Nginx landing page footer docs link updated to docs.sonicverse.tech; purely cosmetic. |
| CODE_OF_CONDUCT.md | Conduct reporting address updated from oss@sonicverse.eu to oss@sonicverse.tech. |
| README.md | Both docs.sonicverse.eu references updated to docs.sonicverse.tech. |
| install-redirect.html | Docs link updated to docs.sonicverse.tech; the anchor was already missing rel="noopener noreferrer" before this PR (pre-existing, not introduced here). |
| AGENTS.md | Both the main docs URL and the /mcp sub-path reference updated to sonicverse.tech. |
| AI_PR_REVIEWER.md | Two docs.sonicverse.eu references updated to docs.sonicverse.tech. |
| CONTRIBUTING.md | Primary documentation link updated to docs.sonicverse.tech. |
| SECURITY.md | Docs link updated to docs.sonicverse.tech. |
| .github/ISSUE_TEMPLATE/bug_report.md | Docs reference updated to docs.sonicverse.tech. |
| .github/ISSUE_TEMPLATE/feature_request.md | Docs reference updated to docs.sonicverse.tech. |
| .github/PULL_REQUEST_TEMPLATE.md | Docs comment reference updated to docs.sonicverse.tech. |
| docs/INSTALL_SHORT_URL_SETUP.md | Bare domain name in a checklist item updated to docs.sonicverse.tech. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sonicverse.eu references] -->|replaced with| B[sonicverse.tech references]

    B --> C[Docs links\nREADME / CONTRIBUTING / SECURITY\nAGENTS / AI_PR_REVIEWER\nIssue & PR templates\ndocs/INSTALL_SHORT_URL_SETUP.md]
    B --> D[Contact address\nCODE_OF_CONDUCT.md\noss@sonicverse.tech]
    B --> E[App footer link\napps/dashboard/app/layout.tsx]
    B --> F[Nginx landing page\ninfrastructure/nginx/index.html.template]
    B --> G[Install redirect page\ninstall-redirect.html]
    B --> H[Runtime default\ninstall.sh POSTHOG_HOST\nhttps://posthog.sonicverse.tech]
```

<sub>Reviews (1): Last reviewed commit: ["refactor: migrate domain references from..."](https://github.com/sonicverse-eu/audiostreaming-stack/commit/c3fa5920e0168d725e8d9c26a156bcbd4ecb5d37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37140672)</sub>

<!-- /greptile_comment -->