### PR TITLE
fix(ci): grant label mirroring workflow token permissions

### DIFF
--- a/.github/workflows/mirror-issue-labels.yml
+++ b/.github/workflows/mirror-issue-labels.yml
@@ -11,6 +11,7 @@ jobs:
     name: Mirror issue labels to connected PRs
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
       pull-requests: write
 


### PR DESCRIPTION
## Summary

Grants the "Mirror issue labels to connected PRs" workflow the write permissions it needs to function. The job was failing with `HttpError: Resource not accessible by integration` (HTTP 403) because the `GITHUB_TOKEN` defaulted to read-only scopes, while `github.rest.issues.addLabels()` requires write access (`x-accepted-github-permissions: issues=write; pull_requests=write`).

Adds an explicit `permissions` block to the job:

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

With this in place, labels from a linked issue are mirrored onto the connected PR as intended.

## Related GitHub issue

Closes #155

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `contents: read` to the `permissions` block of the label-mirroring job. The `issues: write` and `pull-requests: write` entries were already present; this single-line addition makes the token's repository-read scope explicit so that the GraphQL `closingIssuesReferences` query — which requires repository-level read access — no longer fails with HTTP 403.

- Adds `contents: read` as an explicit scope to a job-level `permissions` block that already declared `issues: write` and `pull-requests: write`.
- Without this, GitHub's token scoping sets `contents` to `none` when any explicit `permissions` block is present, which can cause GraphQL queries on repository-scoped fields (e.g. `closingIssuesReferences`) to return 403 before `addLabels()` is ever reached.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line addition to an existing permissions block with no functional logic altered.

The only change is adding `contents: read` to a job-level `permissions` block that already had write scopes for issues and pull-requests. The addition is necessary because GitHub sets any unlisted scope to `none` when an explicit block is present, and the GraphQL queries in the script (`closingIssuesReferences`, `timelineItems`) require at least repository-read access. No logic, triggers, or secrets handling were touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/mirror-issue-labels.yml | Adds `contents: read` to the job-level permissions block; `issues: write` and `pull-requests: write` were already present. Minimal, correct, and well-scoped change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Event
    participant WF as mirror-labels job (GITHUB_TOKEN)
    participant GQL as GitHub GraphQL API
    participant REST as GitHub REST API

    GH->>WF: pull_request (opened/edited/reopened/sync)
    WF->>GQL: closingIssuesReferences query (requires contents:read)
    GQL-->>WF: linked issue numbers
    WF->>GQL: timelineItems (crossRefs) query
    GQL-->>WF: cross-referenced issues
    WF->>REST: issues.get(issueNumber)
    REST-->>WF: issue labels
    WF->>REST: issues.addLabels(prNumber, toAdd)
    REST-->>WF: 200 OK

    GH->>WF: issues (labeled/unlabeled)
    WF->>GQL: timelineItems CROSS_REFERENCED_EVENT (requires contents:read)
    GQL-->>WF: connected PR numbers
    WF->>REST: issues.get(prNumber)
    REST-->>WF: PR current labels
    WF->>REST: issues.addLabels(prNumber, toAdd)
    REST-->>WF: 200 OK
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): grant label mirroring workflow ..."](https://github.com/sonicverse-eu/audiostreaming-stack/commit/b7f44a3ae92690e2df064862ab7d0a773257bc1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37152822)</sub>

<!-- /greptile_comment -->