### PR TITLE
fix: start status API in unified container

### DIFF
--- a/scripts/tests/unified-entrypoint.test.sh
+++ b/scripts/tests/unified-entrypoint.test.sh
@@ -4,28 +4,48 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ENTRYPOINT="$ROOT_DIR/scripts/unified-entrypoint.sh"
 
-if ! awk '
+status_panel_block="$(awk '
     /\[\[ "\$STATUS_PANEL_ENABLED" == "1" \]\]/ {
         in_status_panel_gate = 1
-        next
+    }
+
+    in_status_panel_gate {
+        print
     }
 
     in_status_panel_gate && /^fi$/ {
-        in_status_panel_gate = 0
+        exit
     }
+' "$ENTRYPOINT")"
 
-    in_status_panel_gate && /start_service status-api bash -c/ {
-        starts_status_api = 1
-    }
+assert_contains() {
+    local needle="$1"
+    local message="$2"
 
-    in_status_panel_gate && /gunicorn --bind 127\.0\.0\.1:8080 --workers 2 --timeout 30 server:app/ {
-        binds_status_api = 1
-    }
+    if [[ "$status_panel_block" != *"$needle"* ]]; then
+        echo "$message" >&2
+        exit 1
+    fi
+}
 
-    END {
-        exit starts_status_api && binds_status_api ? 0 : 1
-    }
-' "$ENTRYPOINT"; then
-    echo "missing gated status-api gunicorn startup on 127.0.0.1:8080" >&2
-    exit 1
-fi
+assert_contains \
+    "start_service status-api gunicorn" \
+    "missing gated status-api gunicorn startup"
+assert_contains \
+    "--chdir /opt/sonicverse/status-api" \
+    "status-api gunicorn startup should use --chdir"
+assert_contains \
+    "--bind 127.0.0.1:8080" \
+    "status-api gunicorn startup should bind to 127.0.0.1:8080"
+assert_contains \
+    "--workers 2" \
+    "status-api gunicorn startup should configure two workers"
+assert_contains \
+    "--timeout 30" \
+    "status-api gunicorn startup should configure a 30-second timeout"
+assert_contains \
+    "server:app" \
+    "status-api gunicorn startup should load server:app"
+assert_contains \
+    "wait_for_url status-api \"http://127.0.0.1:8080/api/auth-config\"" \
+    "missing gated status-api readiness check"

--- a/scripts/tests/unified-entrypoint.test.sh
+++ b/scripts/tests/unified-entrypoint.test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENTRYPOINT="$ROOT_DIR/scripts/unified-entrypoint.sh"
+
+if ! awk '
+    /\[\[ "\$STATUS_PANEL_ENABLED" == "1" \]\]/ {
+        in_status_panel_gate = 1
+        next
+    }
+
+    in_status_panel_gate && /^fi$/ {
+        in_status_panel_gate = 0
+    }
+
+    in_status_panel_gate && /start_service status-api bash -c/ {
+        starts_status_api = 1
+    }
+
+    in_status_panel_gate && /gunicorn --bind 127\.0\.0\.1:8080 --workers 2 --timeout 30 server:app/ {
+        binds_status_api = 1
+    }
+
+    END {
+        exit starts_status_api && binds_status_api ? 0 : 1
+    }
+' "$ENTRYPOINT"; then
+    echo "missing gated status-api gunicorn startup on 127.0.0.1:8080" >&2
+    exit 1
+fi

--- a/scripts/unified-entrypoint.sh
+++ b/scripts/unified-entrypoint.sh
@@ -182,6 +182,11 @@ trap stop_services EXIT TERM INT
 start_service icecast icecast2 -c /etc/icecast2/icecast.xml
 wait_for_url icecast "http://127.0.0.1:8000/status-json.xsl"
 
+if [[ "$STATUS_PANEL_ENABLED" == "1" ]]; then
+    start_service status-api bash -c \
+        'cd /opt/sonicverse/status-api && exec gunicorn --bind 127.0.0.1:8080 --workers 2 --timeout 30 server:app'
+fi
+
 start_service liquidsoap liquidsoap /etc/liquidsoap/radio.liq
 start_service nginx nginx -g "daemon off;"
 start_service certificate-watch watch_certificate_updates

--- a/scripts/unified-entrypoint.sh
+++ b/scripts/unified-entrypoint.sh
@@ -183,8 +183,13 @@ start_service icecast icecast2 -c /etc/icecast2/icecast.xml
 wait_for_url icecast "http://127.0.0.1:8000/status-json.xsl"
 
 if [[ "$STATUS_PANEL_ENABLED" == "1" ]]; then
-    start_service status-api bash -c \
-        'cd /opt/sonicverse/status-api && exec gunicorn --bind 127.0.0.1:8080 --workers 2 --timeout 30 server:app'
+    start_service status-api gunicorn \
+        --chdir /opt/sonicverse/status-api \
+        --bind 127.0.0.1:8080 \
+        --workers 2 \
+        --timeout 30 \
+        server:app
+    wait_for_url status-api "http://127.0.0.1:8080/api/auth-config"
 fi
 
 start_service liquidsoap liquidsoap /etc/liquidsoap/radio.liq


### PR DESCRIPTION
## Summary

Starts the status-api service inside the unified container entrypoint so the status panel works when running the full stack in a single container.

- Add a gated startup block in `scripts/unified-entrypoint.sh` that launches `status-api` via gunicorn (`127.0.0.1:8080`, 2 workers, 30s timeout) when `STATUS_PANEL_ENABLED=1`.
- Add `scripts/tests/unified-entrypoint.test.sh` to assert the entrypoint starts the gated status-api gunicorn process on `127.0.0.1:8080`.

The service starts after Icecast is up and before Liquidsoap/nginx, and is skipped entirely when the status panel is disabled.

## Related GitHub issue

Closes #160

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a gated startup block in `scripts/unified-entrypoint.sh` that launches the `status-api` gunicorn process on `127.0.0.1:8080` when `STATUS_PANEL_ENABLED=1`, and includes a `wait_for_url` readiness check before nginx starts. A companion test file verifies all gunicorn flags and the readiness check are present inside the gate.

- `unified-entrypoint.sh`: Inserts an `if STATUS_PANEL_ENABLED` block between icecast and liquidsoap/nginx startup that runs gunicorn with `--chdir`, `--bind`, `--workers`, `--timeout`, and waits for `/api/auth-config` to respond before proceeding.
- `unified-entrypoint.test.sh`: Uses `awk` to extract the gate block and asserts every required flag and the `wait_for_url` call are present.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change follows the established start_service/wait_for_url pattern exactly, is properly gated, and the test locks in every flag and the readiness check.

The new gunicorn startup block mirrors the icecast pattern precisely: background via start_service (registering the PID for monitor_services), then wait_for_url before the next service starts. The previous feedback about the missing readiness check and the bash -c wrapper have both been addressed. The companion test statically verifies all flags and the wait_for_url call are present inside the gate.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/unified-entrypoint.sh | Adds a well-structured gated status-api startup block with readiness check; follows the same start_service/wait_for_url pattern used by icecast. |
| scripts/tests/unified-entrypoint.test.sh | New test file that statically verifies the gated block contains every required gunicorn flag and the wait_for_url readiness check; awk extraction logic correctly captures the full if/fi block. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant EP as unified-entrypoint.sh
    participant IC as icecast2
    participant SA as status-api (gunicorn)
    participant LS as liquidsoap
    participant NX as nginx

    EP->>IC: start_service icecast
    EP->>EP: wait_for_url icecast :8000
    IC-->>EP: ready

    alt "STATUS_PANEL_ENABLED == 1"
        EP->>SA: start_service status-api gunicorn --bind 127.0.0.1:8080
        EP->>EP: wait_for_url status-api :8080/api/auth-config
        SA-->>EP: ready
    end

    EP->>LS: start_service liquidsoap
    EP->>NX: start_service nginx
    EP->>EP: monitor_services (wait -n loop)
```

<sub>Reviews (2): Last reviewed commit: ["fix: wait for status API before nginx"](https://github.com/sonicverse-eu/audiostreaming-stack/commit/abddbeb8cbd1fcff3e4e11eb4e3f6e6fcafb1005) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37200894)</sub>

<!-- /greptile_comment -->