### PR TITLE
Add stack config control plane API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,3 +76,13 @@ STATUS_PANEL_WRITE_ROLES=owner,admin
 
 # Allow dangerous commands like "clear cache" in panel (0 = deny, 1 = allow)
 STATUS_PANEL_ALLOW_RISKY_COMMANDS=0
+
+# ============================================================
+# Stack config control plane (OPTIONAL)
+# ============================================================
+# Canonical runtime config persisted on the shared stack-config volume
+STACK_CONFIG_PATH=/etc/sonicverse/stack.json
+# Comma-separated harbor ports the API may assign to ingests (must match Compose mappings)
+STACK_ALLOWED_INGEST_PORTS=8010,8011
+# Max seconds to wait for a supervised streaming reload to complete
+STACK_APPLY_TIMEOUT_S=120

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ emergency-audio/*.wav
 logs/
 hls-data/
 certbot/
+stack-config/*.json
+stack-config/*.json.bak
+stack-config/*.json.tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,14 +73,21 @@ RUN apt-get update \
     && chmod 0777 /hls
 
 COPY --from=python-deps /opt/venv /opt/venv
-COPY apps/status-api/server.py /opt/sonicverse/status-api/server.py
-COPY services/streaming/icecast/icecast.xml /etc/icecast2/icecast.xml.template
-COPY services/streaming/liquidsoap/radio.liq /etc/liquidsoap/radio.liq
+COPY apps/status-api/ /opt/sonicverse/status-api/
+COPY config/stack.schema.json /opt/sonicverse/config/stack.schema.json
+COPY config/stack.defaults.json /opt/sonicverse/config/stack.defaults.json
+COPY services/streaming/icecast/icecast.xml.j2 /etc/icecast2/icecast.xml.template
+COPY services/streaming/liquidsoap/radio.liq.j2 /etc/liquidsoap/radio.liq.j2
 COPY infrastructure/nginx/nginx.conf /etc/nginx/nginx.conf.template
 COPY infrastructure/nginx/index.html.template /etc/nginx/index.html.template
+COPY infrastructure/nginx/index.streams.html.j2 /etc/nginx/index.streams.html.j2
 COPY scripts/unified-entrypoint.sh /usr/local/bin/sonicverse-entrypoint
+COPY scripts/request-streaming-reload.sh /usr/local/bin/request-streaming-reload.sh
+COPY scripts/render-stack-config.sh /usr/local/bin/render-stack-config.sh
 
-RUN chmod 0755 /usr/local/bin/sonicverse-entrypoint
+RUN chmod 0755 /usr/local/bin/sonicverse-entrypoint \
+    /usr/local/bin/request-streaming-reload.sh \
+    /usr/local/bin/render-stack-config.sh
 
 EXPOSE 80 443 8000 8010 8011 8080
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ All settings are managed via `.env` (copy from `.env.example`):
 | `STATUS_PANEL_HOST` | Optional bind host for status API (default: `127.0.0.1`; auto-uses container IP in Docker when unset) |
 | `STATUS_PANEL_WRITE_ROLES` | Appwrite team roles allowed to manage emergency audio (default: `owner,admin`) |
 | `STATUS_PANEL_ALLOW_RISKY_COMMANDS` | Enable remote restart/SSL renewal commands (`0` by default) |
+| `STACK_CONFIG_PATH` | Canonical stack config file on the shared volume (default: `/etc/sonicverse/stack.json`) |
+| `STACK_ALLOWED_INGEST_PORTS` | Harbor ports the control plane may assign to ingests (default: `8010,8011`) |
+| `STACK_APPLY_TIMEOUT_S` | Max wait for supervised streaming reload (default: `120`) |
+
 The status API now requires `ICECAST_ADMIN_USER` and `ICECAST_ADMIN_PASSWORD`
 to be set explicitly in `.env`; they no longer fall back to built-in example credentials.
 
@@ -378,6 +382,26 @@ docker compose up -d --force-recreate app status-api
 - Stack configuration overview
 - Emergency audio upload/management
 - Role-based write access
+- Stack config control plane API (`/api/stack/*`) for dynamic ingests, outputs, and apply/reload
+
+### Stack config control plane
+
+When `ENABLE_STATUS_PANEL=1`, operators can manage runtime streaming topology through the status API:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/stack/schema` | GET | JSON schema and allowed codec/port enums |
+| `/api/stack/config` | GET/PUT | Read or replace canonical stack config |
+| `/api/stack/ingests/{id}` | PATCH/DELETE | Update or remove harbor ingests |
+| `/api/stack/outputs` | POST | Add a new Icecast output |
+| `/api/stack/outputs/{id}` | PATCH/DELETE | Change stream quality or remove output |
+| `/api/stack/apply` | POST | Validate and apply config via supervised reload |
+| `/api/stack/apply/status` | GET | Apply state machine status |
+| `/api/stack/health` | GET | Compare desired vs effective Icecast mounts |
+
+Canonical config is stored in `./stack-config/stack.json` (bind-mounted to `/etc/sonicverse`). On first boot the stack seeds defaults matching the static topology. Applying changes triggers a supervised Icecast/Liquidsoap reload inside the app container (~5–15s brief interruption).
+
+**v1 limitations:** host port binding changes for new ingests still require updating `.env` and recreating Compose port mappings; mount removal drops active listeners without drain.
 
 ### Deployment on Appwrite Sites
 

--- a/apps/status-api/requirements.txt
+++ b/apps/status-api/requirements.txt
@@ -1,5 +1,6 @@
 docker>=7.1.0
 flask>=3.1.3
+jsonschema>=4.23.0
 flask-cors>=6.0.0
 gunicorn==23.0.0
 jinja2>=3.1.6

--- a/apps/status-api/requirements.txt
+++ b/apps/status-api/requirements.txt
@@ -2,6 +2,7 @@ docker>=7.1.0
 flask>=3.1.3
 flask-cors>=6.0.0
 gunicorn==23.0.0
+jinja2>=3.1.6
 requests==2.33.0
 urllib3>=2.6.3 # not directly required, pinned by Snyk to avoid a vulnerability
 werkzeug==3.1.6

--- a/apps/status-api/server.py
+++ b/apps/status-api/server.py
@@ -19,6 +19,7 @@ import requests
 from docker.errors import DockerException, NotFound
 from flask import Flask, Response, g, jsonify, request
 from flask_cors import CORS
+from stack.routes import register_stack_routes
 from werkzeug.exceptions import RequestEntityTooLarge
 
 app = Flask(__name__)
@@ -733,6 +734,19 @@ def api_commands_run():
     except Exception:
         app.logger.exception("Unexpected command execution failure for %s (%s)", command_id, service)
         return jsonify({"error": "Unexpected command failure"}), 500
+
+
+# ============================================================
+# Stack config control plane
+# ============================================================
+
+register_stack_routes(
+    app,
+    require_auth=require_auth,
+    require_operator=require_operator,
+    fetch_icecast_stats=fetch_icecast_stats,
+    parse_stats=parse_stats,
+)
 
 
 # ============================================================

--- a/apps/status-api/stack/apply.py
+++ b/apps/status-api/stack/apply.py
@@ -1,0 +1,127 @@
+"""Apply stack config via supervised in-container reload."""
+
+import os
+import time
+from pathlib import Path
+
+import docker
+from docker.errors import DockerException, NotFound
+
+from stack.render import render_all
+from stack.schema import validate_stack_config
+from stack.store import read_apply_status, read_config, strip_metadata, write_apply_status
+
+APP_CONTAINER_NAME = os.getenv("STACK_APP_CONTAINER", "sonicverse-app")
+RELOAD_MARKER_PATH = Path(os.getenv("STACK_RELOAD_MARKER_PATH", "/run/sonicverse/reload-request"))
+APPLY_TIMEOUT_S = int(os.getenv("STACK_APPLY_TIMEOUT_S", "120"))
+
+LIQUIDSOAP_OUTPUT = Path(os.getenv("STACK_LIQUIDSOAP_OUTPUT", "/etc/liquidsoap/radio.liq"))
+ICECAST_TEMPLATE_OUTPUT = Path(
+    os.getenv("STACK_ICECAST_TEMPLATE_OUTPUT", "/etc/icecast2/icecast.xml.template")
+)
+INDEX_TEMPLATE_PATH = Path(
+    os.getenv("STACK_INDEX_TEMPLATE_PATH", "/etc/nginx/index.html.template")
+)
+INDEX_OUTPUT = Path(os.getenv("STACK_INDEX_OUTPUT", "/usr/share/nginx/html/index.html"))
+
+
+def _get_docker_client():
+    return docker.from_env()
+
+
+def _running_in_app_container():
+    return Path("/.dockerenv").exists() and Path("/usr/local/bin/sonicverse-entrypoint").exists()
+
+
+def _write_reload_marker():
+    RELOAD_MARKER_PATH.parent.mkdir(parents=True, exist_ok=True)
+    RELOAD_MARKER_PATH.write_text(str(int(time.time())), encoding="utf-8")
+
+
+def _trigger_reload_external():
+    client = _get_docker_client()
+    container = client.containers.get(APP_CONTAINER_NAME)
+    exit_code, output = container.exec_run(
+        ["/usr/local/bin/request-streaming-reload.sh"],
+        demux=True,
+    )
+    stdout = (output[0] or b"").decode("utf-8", errors="replace").strip()
+    stderr = (output[1] or b"").decode("utf-8", errors="replace").strip()
+    if exit_code != 0:
+        message = stderr or stdout or "reload request failed"
+        raise RuntimeError(message)
+
+
+def trigger_reload():
+    if _running_in_app_container():
+        _write_reload_marker()
+        return
+    _trigger_reload_external()
+
+
+def pre_render_config(config):
+    """Render config artifacts to disk (used by entrypoint render script)."""
+    station_name = os.getenv("STATION_NAME", "Radio Station")
+    contact_email = os.getenv("STATION_ADMIN_EMAIL", "admin@example.com")
+    hostname = os.getenv("ICECAST_HOSTNAME", "localhost")
+
+    artifacts = render_all(
+        config,
+        index_template_path=str(INDEX_TEMPLATE_PATH) if INDEX_TEMPLATE_PATH.exists() else None,
+        station_name=station_name,
+        contact_email=contact_email,
+        hostname=hostname,
+    )
+
+    LIQUIDSOAP_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    LIQUIDSOAP_OUTPUT.write_text(artifacts["radio.liq"], encoding="utf-8")
+
+    ICECAST_TEMPLATE_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    ICECAST_TEMPLATE_OUTPUT.write_text(artifacts["icecast.xml"], encoding="utf-8")
+
+    if "index.html" in artifacts:
+        INDEX_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+        INDEX_OUTPUT.write_text(artifacts["index.html"], encoding="utf-8")
+
+    return artifacts
+
+
+def apply_config(config=None):
+    """Validate config and request supervised reload in the app container."""
+    config = config or read_config()
+    errors = validate_stack_config(strip_metadata(config))
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    write_apply_status({"state": "validating"})
+    try:
+        write_apply_status({"state": "applying"})
+        trigger_reload()
+        final_status = wait_for_apply_completion()
+        if final_status.get("state") == "failed":
+            raise RuntimeError(final_status.get("error", "apply failed"))
+        return final_status
+    except (DockerException, NotFound, RuntimeError, ValueError, OSError) as exc:
+        write_apply_status({
+            "state": "failed",
+            "error": str(exc),
+        })
+        raise
+
+
+def wait_for_apply_completion(timeout_s=None):
+    timeout_s = timeout_s or APPLY_TIMEOUT_S
+    deadline = time.time() + timeout_s
+    last_state = "idle"
+
+    while time.time() < deadline:
+        status = read_apply_status()
+        last_state = status.get("state", "idle")
+        if last_state in {"applied", "failed"}:
+            return status
+        time.sleep(1)
+
+    return {
+        "state": "failed",
+        "error": f"Apply timed out after {timeout_s}s (last state: {last_state})",
+    }

--- a/apps/status-api/stack/render.py
+++ b/apps/status-api/stack/render.py
@@ -1,0 +1,168 @@
+"""Jinja2 rendering for stack config."""
+
+import os
+import re
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from stack.schema import _resolve_repo_root
+
+_REPO_ROOT = _resolve_repo_root()
+
+
+def _first_existing_path(*candidates):
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = Path(candidate)
+        if path.exists():
+            return path
+    for candidate in reversed(candidates):
+        if candidate:
+            return Path(candidate)
+    raise FileNotFoundError("No template directory candidates provided")
+
+
+TEMPLATE_DIRS = {
+    "liquidsoap": _first_existing_path(
+        os.getenv("STACK_LIQUIDSOAP_TEMPLATE_DIR", ""),
+        "/etc/liquidsoap",
+        _REPO_ROOT / "services" / "streaming" / "liquidsoap",
+    ),
+    "icecast": _first_existing_path(
+        os.getenv("STACK_ICECAST_TEMPLATE_DIR", ""),
+        "/etc/icecast2",
+        _REPO_ROOT / "services" / "streaming" / "icecast",
+    ),
+    "nginx": _first_existing_path(
+        os.getenv("STACK_NGINX_TEMPLATE_DIR", ""),
+        "/etc/nginx",
+        _REPO_ROOT / "infrastructure" / "nginx",
+    ),
+}
+
+OUTPUT_LABELS = {
+    ("mp3", 128): ("MP3 (128kbps)", "Standard quality • Widely compatible"),
+    ("mp3", 192): ("MP3 (192kbps)", "High quality • Widely compatible"),
+    ("mp3", 320): ("MP3 (320kbps)", "High quality • Maximum compatibility"),
+    ("fdkaac", 128): ("AAC (128kbps)", "Modern codec • Mobile optimized"),
+    ("fdkaac", 192): ("AAC (192kbps)", "High quality • Mobile optimized"),
+    ("vorbis", 128): ("Ogg Vorbis (128kbps)", "Open format • Linux friendly"),
+}
+
+
+def _create_env(template_dir):
+    return Environment(
+        loader=FileSystemLoader(str(template_dir)),
+        autoescape=select_autoescape(default=False),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+    )
+
+
+def _output_cards(config):
+    cards = []
+    for output in config.get("outputs", []):
+        if not output.get("enabled"):
+            continue
+        codec = output.get("codec")
+        bitrate = output.get("bitrate")
+        label, description = OUTPUT_LABELS.get(
+            (codec, bitrate),
+            (f"{codec.upper()} ({bitrate}kbps)", "Stream output"),
+        )
+        cards.append({
+            **output,
+            "label": label,
+            "description": description,
+        })
+    return cards
+
+
+def render_liquidsoap(config):
+    env = _create_env(TEMPLATE_DIRS["liquidsoap"])
+    template = env.get_template("radio.liq.j2")
+    return template.render(
+        ingests=config.get("ingests", []),
+        outputs=config.get("outputs", []),
+        hls=config.get("hls", {}),
+        processing=config.get("processing", {}),
+    )
+
+
+def render_icecast(config):
+    env = _create_env(TEMPLATE_DIRS["icecast"])
+    template = env.get_template("icecast.xml.j2")
+    return template.render(outputs=config.get("outputs", []))
+
+
+def render_stream_cards(config):
+    env = _create_env(TEMPLATE_DIRS["nginx"])
+    template = env.get_template("index.streams.html.j2")
+    return template.render(
+        outputs=_output_cards(config),
+        hls=config.get("hls", {}),
+    )
+
+
+def render_index_html(config, index_template_path, station_name, contact_email, hostname):
+    """Render full landing page by replacing the streams section in index.html.template."""
+    template_path = Path(index_template_path)
+    base_html = template_path.read_text(encoding="utf-8")
+    stream_cards = render_stream_cards(config)
+
+    marker_start = '<div class="section-title">Available Streams</div>'
+    marker_end = '<div class="contact-info">'
+
+    start_idx = base_html.find(marker_start)
+    end_idx = base_html.find(marker_end)
+    if start_idx == -1 or end_idx == -1:
+        raise ValueError("index.html.template is missing stream section markers")
+
+    station_name_esc = _escape_html(station_name)
+    contact_email_esc = _escape_html(contact_email)
+
+    prefix = base_html[:start_idx]
+    suffix = base_html[end_idx:]
+
+    rendered = prefix + stream_cards + "\n        \n        " + suffix
+    rendered = rendered.replace("${STATION_NAME_ESC}", station_name_esc)
+    rendered = rendered.replace("${STATION_ADMIN_EMAIL_ESC}", contact_email_esc)
+    rendered = rendered.replace("${ICECAST_HOSTNAME}", hostname)
+    return rendered
+
+
+def _escape_html(value):
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
+
+
+def render_all(config, index_template_path=None, station_name=None, contact_email=None, hostname=None):
+    """Render all stack config artifacts."""
+    artifacts = {
+        "radio.liq": render_liquidsoap(config),
+        "icecast.xml": render_icecast(config),
+    }
+
+    if index_template_path:
+        artifacts["index.html"] = render_index_html(
+            config,
+            index_template_path,
+            station_name or os.getenv("STATION_NAME", "Radio Station"),
+            contact_email or os.getenv("STATION_ADMIN_EMAIL", "admin@example.com"),
+            hostname or os.getenv("ICECAST_HOSTNAME", "localhost"),
+        )
+
+    return artifacts
+
+
+def normalize_whitespace(text):
+    """Collapse runs of blank lines for stable snapshot comparison."""
+    return re.sub(r"\n{3,}", "\n\n", text.strip()) + "\n"

--- a/apps/status-api/stack/routes.py
+++ b/apps/status-api/stack/routes.py
@@ -1,0 +1,218 @@
+"""Stack config API routes."""
+
+import copy
+
+from flask import jsonify, request
+
+from stack.apply import apply_config
+from stack.schema import get_schema_response
+from stack.store import get_config_metadata, read_apply_status, read_config, write_config
+
+
+def register_stack_routes(app, require_auth, require_operator, fetch_icecast_stats, parse_stats):
+    @app.route("/api/stack/schema")
+    @require_auth
+    def api_stack_schema():
+        return jsonify(get_schema_response())
+
+    @app.route("/api/stack/config")
+    @require_auth
+    def api_stack_config_get():
+        config, metadata = get_config_metadata()
+        return jsonify({"config": config, "metadata": metadata})
+
+    @app.route("/api/stack/config", methods=["PUT"])
+    @require_operator
+    def api_stack_config_put():
+        payload = request.get_json() or {}
+        config = payload.get("config", payload)
+        try:
+            saved = write_config(config)
+            return jsonify({"ok": True, "config": saved})
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+
+    @app.route("/api/stack/ingests/<ingest_id>", methods=["PATCH"])
+    @require_operator
+    def api_stack_ingest_patch(ingest_id):
+        data = request.get_json() or {}
+        config = read_config()
+        ingests = config.get("ingests", [])
+        target = next((item for item in ingests if item.get("id") == ingest_id), None)
+
+        if data.get("enabled") is False:
+            enabled_count = sum(1 for item in ingests if item.get("enabled"))
+            if target and target.get("enabled") and enabled_count <= 1:
+                return jsonify({"error": "Cannot disable the last enabled ingest"}), 400
+
+        if target is None:
+            if data.get("create"):
+                ingests.append({
+                    "id": ingest_id,
+                    "type": "harbor",
+                    "port": data["port"],
+                    "priority": data.get("priority", len(ingests) + 1),
+                    "enabled": data.get("enabled", True),
+                })
+            else:
+                return jsonify({"error": f"Ingest not found: {ingest_id}"}), 404
+        else:
+            for key, value in data.items():
+                if key != "create":
+                    target[key] = value
+
+        updated = copy.deepcopy(config)
+        updated["ingests"] = ingests
+        try:
+            saved = write_config(updated)
+            return jsonify({"ok": True, "config": saved})
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+
+    @app.route("/api/stack/ingests/<ingest_id>", methods=["DELETE"])
+    @require_operator
+    def api_stack_ingest_delete(ingest_id):
+        config = read_config()
+        ingests = config.get("ingests", [])
+        enabled = [item for item in ingests if item.get("enabled")]
+        target = next((item for item in ingests if item.get("id") == ingest_id), None)
+        if target is None:
+            return jsonify({"error": f"Ingest not found: {ingest_id}"}), 404
+        if target.get("enabled") and len(enabled) <= 1:
+            return jsonify({"error": "Cannot remove the last enabled ingest"}), 400
+
+        updated = copy.deepcopy(config)
+        updated["ingests"] = [item for item in ingests if item.get("id") != ingest_id]
+        try:
+            saved = write_config(updated)
+            return jsonify({"ok": True, "config": saved})
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+
+    @app.route("/api/stack/outputs/<output_id>", methods=["PATCH"])
+    @require_operator
+    def api_stack_output_patch(output_id):
+        data = request.get_json() or {}
+        config = read_config()
+        outputs = config.get("outputs", [])
+        target = next((item for item in outputs if item.get("id") == output_id), None)
+        if target is None:
+            return jsonify({"error": f"Output not found: {output_id}"}), 404
+
+        for key, value in data.items():
+            target[key] = value
+
+        updated = copy.deepcopy(config)
+        updated["outputs"] = outputs
+        try:
+            saved = write_config(updated)
+            return jsonify({"ok": True, "config": saved})
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+
+    @app.route("/api/stack/outputs", methods=["POST"])
+    @require_operator
+    def api_stack_output_create():
+        data = request.get_json() or {}
+        required = ("id", "mount", "codec", "bitrate")
+        missing = [field for field in required if field not in data]
+        if missing:
+            return jsonify({"error": f"Missing fields: {', '.join(missing)}"}), 400
+
+        config = read_config()
+        outputs = config.get("outputs", [])
+        if any(item.get("id") == data["id"] for item in outputs):
+            return jsonify({"error": f"Output already exists: {data['id']}"}), 400
+
+        outputs.append({
+            "id": data["id"],
+            "type": "icecast",
+            "mount": data["mount"],
+            "codec": data["codec"],
+            "bitrate": data["bitrate"],
+            "samplerate": data.get("samplerate", 44100),
+            "channels": data.get("channels", 2),
+            "enabled": data.get("enabled", True),
+        })
+
+        updated = copy.deepcopy(config)
+        updated["outputs"] = outputs
+        try:
+            saved = write_config(updated)
+            return jsonify({"ok": True, "config": saved})
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+
+    @app.route("/api/stack/outputs/<output_id>", methods=["DELETE"])
+    @require_operator
+    def api_stack_output_delete(output_id):
+        config = read_config()
+        outputs = config.get("outputs", [])
+        hls_enabled = config.get("hls", {}).get("enabled") and config.get("hls", {}).get("variants")
+        enabled_outputs = [item for item in outputs if item.get("enabled")]
+        target = next((item for item in outputs if item.get("id") == output_id), None)
+        if target is None:
+            return jsonify({"error": f"Output not found: {output_id}"}), 404
+        if target.get("enabled") and len(enabled_outputs) <= 1 and not hls_enabled:
+            return jsonify({"error": "Cannot remove the last enabled output"}), 400
+
+        updated = copy.deepcopy(config)
+        updated["outputs"] = [item for item in outputs if item.get("id") != output_id]
+        try:
+            saved = write_config(updated)
+            return jsonify({"ok": True, "config": saved})
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+
+    @app.route("/api/stack/apply", methods=["POST"])
+    @require_operator
+    def api_stack_apply():
+        payload = request.get_json() or {}
+        config = payload.get("config")
+        try:
+            if config is not None:
+                write_config(config)
+            status = apply_config()
+            return jsonify({"ok": True, "status": status})
+        except ValueError as exc:
+            return jsonify({"ok": False, "error": str(exc), "status": read_apply_status()}), 400
+        except Exception as exc:
+            app.logger.warning("Stack apply failed: %s", exc)
+            return jsonify({
+                "ok": False,
+                "error": str(exc),
+                "status": read_apply_status(),
+            }), 502
+
+    @app.route("/api/stack/apply/status")
+    @require_auth
+    def api_stack_apply_status():
+        return jsonify(read_apply_status())
+
+    @app.route("/api/stack/health")
+    @require_auth
+    def api_stack_health():
+        config = read_config()
+        desired_mounts = {
+            output["mount"]
+            for output in config.get("outputs", [])
+            if output.get("enabled")
+        }
+
+        stats = fetch_icecast_stats()
+        parsed = parse_stats(stats)
+        effective_mounts = {mount["mount"] for mount in parsed.get("mounts", [])}
+
+        missing = sorted(desired_mounts - effective_mounts)
+        extra = sorted(effective_mounts - desired_mounts)
+
+        healthy = not missing and parsed.get("status") == "ok"
+        return jsonify({
+            "healthy": healthy,
+            "desired_mounts": sorted(desired_mounts),
+            "effective_mounts": sorted(effective_mounts),
+            "missing_mounts": missing,
+            "extra_mounts": extra,
+            "apply_status": read_apply_status(),
+            "icecast_status": parsed.get("status"),
+        })

--- a/apps/status-api/stack/schema.py
+++ b/apps/status-api/stack/schema.py
@@ -5,6 +5,8 @@ import os
 import re
 from pathlib import Path
 
+from jsonschema import Draft202012Validator
+
 MOUNT_PATTERN = re.compile(r"^/[a-z0-9-]+$")
 ICECAST_CODECS = {"mp3", "fdkaac", "vorbis"}
 
@@ -54,6 +56,18 @@ def _validate_unique(values, field_name, errors):
         seen.add(value)
 
 
+def _format_schema_error(error):
+    path = ".".join(str(part) for part in error.absolute_path)
+    location = path or "config"
+    return f"{location}: {error.message}"
+
+
+def _validate_against_schema(config, errors):
+    validator = Draft202012Validator(load_schema())
+    for error in sorted(validator.iter_errors(config), key=lambda item: list(item.absolute_path)):
+        errors.append(_format_schema_error(error))
+
+
 def validate_stack_config(config, allowed_ports=None):
     """Validate stack config against schema and business rules."""
     errors = []
@@ -61,20 +75,15 @@ def validate_stack_config(config, allowed_ports=None):
     if not isinstance(config, dict):
         return ["Config must be a JSON object"]
 
-    if config.get("version") != 1:
-        errors.append("Unsupported config version (expected 1)")
-
-    ingests = config.get("ingests")
-    outputs = config.get("outputs")
-    hls = config.get("hls")
-    processing = config.get("processing")
-
-    for key in ("ingests", "outputs", "hls", "processing"):
-        if key not in config:
-            errors.append(f"Missing required field: {key}")
+    _validate_against_schema(config, errors)
 
     if errors:
         return errors
+
+    ingests = config["ingests"]
+    outputs = config["outputs"]
+    hls = config["hls"]
+    processing = config["processing"]
 
     allowed_ports = allowed_ports or get_allowed_ingest_ports()
 
@@ -86,8 +95,6 @@ def validate_stack_config(config, allowed_ports=None):
     _validate_unique([item.get("port") for item in ingests], "ingest port", errors)
 
     for ingest in ingests:
-        if ingest.get("type") != "harbor":
-            errors.append(f"Ingest {ingest.get('id')}: unsupported type")
         port = ingest.get("port")
         if port not in allowed_ports:
             errors.append(
@@ -102,14 +109,6 @@ def validate_stack_config(config, allowed_ports=None):
 
     _validate_unique([item.get("id") for item in outputs], "output id", errors)
     _validate_unique([item.get("mount") for item in outputs if item.get("enabled")], "mount", errors)
-
-    for output in outputs:
-        mount = output.get("mount", "")
-        if not MOUNT_PATTERN.match(mount):
-            errors.append(f"Output {output.get('id')}: invalid mount name {mount}")
-        codec = output.get("codec")
-        if codec not in ICECAST_CODECS:
-            errors.append(f"Output {output.get('id')}: unsupported codec {codec}")
 
     if hls.get("enabled"):
         _validate_unique([item.get("id") for item in hls.get("variants", [])], "HLS variant id", errors)

--- a/apps/status-api/stack/schema.py
+++ b/apps/status-api/stack/schema.py
@@ -1,0 +1,132 @@
+"""Stack config validation."""
+
+import json
+import os
+import re
+from pathlib import Path
+
+MOUNT_PATTERN = re.compile(r"^/[a-z0-9-]+$")
+ICECAST_CODECS = {"mp3", "fdkaac", "vorbis"}
+
+
+def _resolve_repo_root():
+    env_root = os.getenv("STACK_REPO_ROOT")
+    if env_root:
+        return Path(env_root)
+
+    candidate = Path(__file__).resolve().parents[3]
+    if (candidate / "config" / "stack.defaults.json").exists():
+        return candidate
+
+    return Path("/opt/sonicverse")
+
+
+_REPO_ROOT = _resolve_repo_root()
+SCHEMA_PATH = Path(os.getenv("STACK_SCHEMA_PATH", _REPO_ROOT / "config" / "stack.schema.json"))
+DEFAULTS_PATH = Path(os.getenv("STACK_DEFAULTS_PATH", _REPO_ROOT / "config" / "stack.defaults.json"))
+
+
+def get_allowed_ingest_ports():
+    raw = os.getenv("STACK_ALLOWED_INGEST_PORTS", "8010,8011")
+    ports = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if part.isdigit():
+            ports.add(int(part))
+    return ports or {8010, 8011}
+
+
+def load_schema():
+    with SCHEMA_PATH.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_defaults():
+    with DEFAULTS_PATH.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _validate_unique(values, field_name, errors):
+    seen = set()
+    for value in values:
+        if value in seen:
+            errors.append(f"Duplicate {field_name}: {value}")
+        seen.add(value)
+
+
+def validate_stack_config(config, allowed_ports=None):
+    """Validate stack config against schema and business rules."""
+    errors = []
+
+    if not isinstance(config, dict):
+        return ["Config must be a JSON object"]
+
+    if config.get("version") != 1:
+        errors.append("Unsupported config version (expected 1)")
+
+    ingests = config.get("ingests")
+    outputs = config.get("outputs")
+    hls = config.get("hls")
+    processing = config.get("processing")
+
+    for key in ("ingests", "outputs", "hls", "processing"):
+        if key not in config:
+            errors.append(f"Missing required field: {key}")
+
+    if errors:
+        return errors
+
+    allowed_ports = allowed_ports or get_allowed_ingest_ports()
+
+    enabled_ingests = [item for item in ingests if item.get("enabled")]
+    if not enabled_ingests:
+        errors.append("At least one ingest must be enabled")
+
+    _validate_unique([item.get("id") for item in ingests], "ingest id", errors)
+    _validate_unique([item.get("port") for item in ingests], "ingest port", errors)
+
+    for ingest in ingests:
+        if ingest.get("type") != "harbor":
+            errors.append(f"Ingest {ingest.get('id')}: unsupported type")
+        port = ingest.get("port")
+        if port not in allowed_ports:
+            errors.append(
+                f"Ingest {ingest.get('id')}: port {port} not in allowed ports "
+                f"({', '.join(str(p) for p in sorted(allowed_ports))})"
+            )
+
+    enabled_outputs = [item for item in outputs if item.get("enabled")]
+    enabled_hls = hls.get("enabled") and hls.get("variants")
+    if not enabled_outputs and not enabled_hls:
+        errors.append("At least one Icecast output or HLS variant must be enabled")
+
+    _validate_unique([item.get("id") for item in outputs], "output id", errors)
+    _validate_unique([item.get("mount") for item in outputs if item.get("enabled")], "mount", errors)
+
+    for output in outputs:
+        mount = output.get("mount", "")
+        if not MOUNT_PATTERN.match(mount):
+            errors.append(f"Output {output.get('id')}: invalid mount name {mount}")
+        codec = output.get("codec")
+        if codec not in ICECAST_CODECS:
+            errors.append(f"Output {output.get('id')}: unsupported codec {codec}")
+
+    if hls.get("enabled"):
+        _validate_unique([item.get("id") for item in hls.get("variants", [])], "HLS variant id", errors)
+
+    for key in ("crossfade_seconds", "buffer_seconds", "max_buffer_seconds"):
+        if key not in processing:
+            errors.append(f"Missing processing field: {key}")
+
+    return errors
+
+
+def get_schema_response():
+    """Return schema metadata for API consumers."""
+    return {
+        "version": 1,
+        "icecast_codecs": sorted(ICECAST_CODECS),
+        "allowed_ingest_ports": sorted(get_allowed_ingest_ports()),
+        "mount_pattern": MOUNT_PATTERN.pattern,
+        "schema": load_schema(),
+    }

--- a/apps/status-api/stack/store.py
+++ b/apps/status-api/stack/store.py
@@ -1,0 +1,98 @@
+"""Persistent stack config store."""
+
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+
+from stack.schema import load_defaults, validate_stack_config
+
+STACK_CONFIG_PATH = Path(os.getenv("STACK_CONFIG_PATH", "/etc/sonicverse/stack.json"))
+STACK_APPLY_STATUS_PATH = Path(
+    os.getenv("STACK_APPLY_STATUS_PATH", "/etc/sonicverse/stack.apply.json")
+)
+STACK_CONFIG_BACKUP_PATH = STACK_CONFIG_PATH.with_suffix(".json.bak")
+
+
+def _ensure_parent(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def read_config():
+    if not STACK_CONFIG_PATH.exists():
+        return load_defaults()
+    with STACK_CONFIG_PATH.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def strip_metadata(config):
+    cleaned = dict(config)
+    cleaned.pop("updated_at", None)
+    return cleaned
+
+
+def write_config(config, backup=True):
+    cleaned = strip_metadata(config)
+    errors = validate_stack_config(cleaned)
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    _ensure_parent(STACK_CONFIG_PATH)
+
+    if backup and STACK_CONFIG_PATH.exists():
+        shutil.copy2(STACK_CONFIG_PATH, STACK_CONFIG_BACKUP_PATH)
+
+    temp_path = STACK_CONFIG_PATH.with_suffix(".json.tmp")
+    payload = {
+        **cleaned,
+        "updated_at": int(time.time()),
+    }
+    with temp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+    temp_path.replace(STACK_CONFIG_PATH)
+    return payload
+
+
+def seed_defaults_if_missing():
+    if STACK_CONFIG_PATH.exists():
+        return False
+    defaults = load_defaults()
+    write_config(defaults, backup=False)
+    return True
+
+
+def get_config_metadata():
+    config = read_config()
+    metadata = {
+        "version": config.get("version", 1),
+        "updated_at": config.get("updated_at"),
+    }
+    if STACK_CONFIG_PATH.exists():
+        metadata["path"] = str(STACK_CONFIG_PATH)
+        metadata["exists"] = True
+    else:
+        metadata["exists"] = False
+    return config, metadata
+
+
+def read_apply_status():
+    if not STACK_APPLY_STATUS_PATH.exists():
+        return {"state": "idle"}
+    with STACK_APPLY_STATUS_PATH.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_apply_status(status):
+    _ensure_parent(STACK_APPLY_STATUS_PATH)
+    temp_path = STACK_APPLY_STATUS_PATH.with_suffix(".json.tmp")
+    payload = {
+        **status,
+        "updated_at": int(time.time()),
+    }
+    with temp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+    temp_path.replace(STACK_APPLY_STATUS_PATH)
+    return payload

--- a/apps/status-api/tests/test_stack_routes.py
+++ b/apps/status-api/tests/test_stack_routes.py
@@ -1,0 +1,131 @@
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+import unittest.mock as mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from stack.schema import load_defaults  # noqa: E402
+
+SERVER_PATH = ROOT / "server.py"
+SPEC = importlib.util.spec_from_file_location("status_api_server", SERVER_PATH)
+status_server = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(status_server)
+
+
+class StackRouteTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+
+        self.client = status_server.app.test_client()
+        self.auth_headers = {"Authorization": "Bearer test-token"}
+
+        self.config_path = pathlib.Path(self.tempdir.name) / "stack.json"
+        self.apply_path = pathlib.Path(self.tempdir.name) / "stack.apply.json"
+
+        self.stack_store = sys.modules["stack.store"]
+        self.stack_apply = sys.modules["stack.apply"]
+
+        self.original_config_path = self.stack_store.STACK_CONFIG_PATH
+        self.original_apply_path = self.stack_store.STACK_APPLY_STATUS_PATH
+        self.addCleanup(self.restore_paths)
+
+        self.stack_store.STACK_CONFIG_PATH = self.config_path
+        self.stack_store.STACK_APPLY_STATUS_PATH = self.apply_path
+        self.stack_store.STACK_CONFIG_BACKUP_PATH = self.config_path.with_suffix(".json.bak")
+
+        defaults = load_defaults()
+        self.config_path.write_text(json.dumps(defaults), encoding="utf-8")
+
+    def restore_paths(self):
+        self.stack_store.STACK_CONFIG_PATH = self.original_config_path
+        self.stack_store.STACK_APPLY_STATUS_PATH = self.original_apply_path
+
+    def auth_patch(self):
+        return mock.patch.object(
+            status_server,
+            "get_appwrite_context",
+            return_value={"user_id": "test-user", "roles": {"admin"}},
+        )
+
+    def viewer_patch(self):
+        return mock.patch.object(
+            status_server,
+            "get_appwrite_context",
+            return_value={"user_id": "test-user", "roles": {"member"}},
+        )
+
+    def test_schema_endpoint_requires_auth(self):
+        response = self.client.get("/api/stack/schema")
+        self.assertEqual(response.status_code, 401)
+
+    def test_get_config_returns_defaults(self):
+        with self.auth_patch():
+            response = self.client.get("/api/stack/config", headers=self.auth_headers)
+        self.assertEqual(response.status_code, 200)
+        body = response.json
+        self.assertEqual(body["config"]["version"], 1)
+        self.assertEqual(len(body["config"]["outputs"]), 6)
+
+    def test_put_config_requires_operator(self):
+        config = load_defaults()
+        with self.viewer_patch():
+            response = self.client.put(
+                "/api/stack/config",
+                json={"config": config},
+                headers=self.auth_headers,
+            )
+        self.assertEqual(response.status_code, 403)
+
+    def test_patch_output_bitrate(self):
+        with self.auth_patch():
+            response = self.client.patch(
+                "/api/stack/outputs/mp3-128",
+                json={"bitrate": 160},
+                headers=self.auth_headers,
+            )
+        self.assertEqual(response.status_code, 200)
+        updated = response.json["config"]
+        target = next(item for item in updated["outputs"] if item["id"] == "mp3-128")
+        self.assertEqual(target["bitrate"], 160)
+
+    def test_apply_triggers_reload(self):
+        with self.auth_patch(), mock.patch.object(
+            self.stack_apply,
+            "trigger_reload",
+        ) as trigger_reload, mock.patch.object(
+            self.stack_apply,
+            "wait_for_apply_completion",
+            return_value={"state": "applied"},
+        ):
+            response = self.client.post(
+                "/api/stack/apply",
+                json={},
+                headers=self.auth_headers,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        trigger_reload.assert_called_once()
+        self.assertTrue(response.json["ok"])
+
+    def test_health_reports_missing_mounts(self):
+        with self.auth_patch(), mock.patch.object(
+            status_server,
+            "fetch_icecast_stats",
+            return_value={"icestats": {"source": []}},
+        ):
+            response = self.client.get("/api/stack/health", headers=self.auth_headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json["healthy"])
+        self.assertTrue(response.json["missing_mounts"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/status-api/tests/test_stack_schema.py
+++ b/apps/status-api/tests/test_stack_schema.py
@@ -1,0 +1,107 @@
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from stack.render import normalize_whitespace, render_icecast, render_liquidsoap  # noqa: E402
+from stack.schema import load_defaults, validate_stack_config  # noqa: E402
+
+
+class StackSchemaTests(unittest.TestCase):
+    def test_defaults_are_valid(self):
+        config = load_defaults()
+        errors = validate_stack_config(config)
+        self.assertEqual(errors, [])
+
+    def test_rejects_duplicate_mounts(self):
+        config = load_defaults()
+        config["outputs"].append({
+            "id": "dup",
+            "type": "icecast",
+            "mount": "/stream-mp3-128",
+            "codec": "mp3",
+            "bitrate": 64,
+            "samplerate": 44100,
+            "channels": 2,
+            "enabled": True,
+        })
+        errors = validate_stack_config(config)
+        self.assertTrue(any("Duplicate mount" in error for error in errors))
+
+    def test_rejects_disallowed_ingest_port(self):
+        config = load_defaults()
+        config["ingests"].append({
+            "id": "extra",
+            "type": "harbor",
+            "port": 9999,
+            "priority": 3,
+            "enabled": True,
+        })
+        errors = validate_stack_config(config, allowed_ports={8010, 8011})
+        self.assertTrue(any("not in allowed ports" in error for error in errors))
+
+    def test_rejects_all_disabled_ingests(self):
+        config = load_defaults()
+        for ingest in config["ingests"]:
+            ingest["enabled"] = False
+        errors = validate_stack_config(config)
+        self.assertIn("At least one ingest must be enabled", errors)
+
+
+class StackRenderTests(unittest.TestCase):
+    def setUp(self):
+        self.config = load_defaults()
+        repo_root = pathlib.Path(__file__).resolve().parents[3]
+        self.radio_liq = (repo_root / "services/streaming/liquidsoap/radio.liq").read_text(
+            encoding="utf-8"
+        )
+        self.icecast_xml = (repo_root / "services/streaming/icecast/icecast.xml").read_text(
+            encoding="utf-8"
+        )
+
+    def test_liquidsoap_renders_all_mounts(self):
+        rendered = render_liquidsoap(self.config)
+        for mount in (
+            "/stream-mp3-128",
+            "/stream-mp3-192",
+            "/stream-mp3-320",
+            "/stream-aac-128",
+            "/stream-aac-192",
+            "/stream-ogg-128",
+        ):
+            self.assertIn(f'mount="{mount}"', rendered)
+
+    def test_liquidsoap_renders_harbor_ports(self):
+        rendered = render_liquidsoap(self.config)
+        self.assertIn("port=8010", rendered)
+        self.assertIn("port=8011", rendered)
+
+    def test_icecast_renders_all_mounts(self):
+        rendered = render_icecast(self.config)
+        for mount in (
+            "/stream-mp3-128",
+            "/stream-mp3-192",
+            "/stream-mp3-320",
+            "/stream-aac-128",
+            "/stream-aac-192",
+            "/stream-ogg-128",
+        ):
+            self.assertIn(f"<mount-name>{mount}</mount-name>", rendered)
+
+    def test_liquidsoap_matches_static_structure(self):
+        rendered = normalize_whitespace(render_liquidsoap(self.config))
+        static = normalize_whitespace(self.radio_liq)
+        for marker in (
+            "output.icecast(",
+            "output.file.hls(",
+            "input.harbor(",
+            "blank.detect(",
+        ):
+            self.assertIn(marker, rendered)
+            self.assertIn(marker, static)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/status-api/tests/test_stack_schema.py
+++ b/apps/status-api/tests/test_stack_schema.py
@@ -49,6 +49,24 @@ class StackSchemaTests(unittest.TestCase):
         errors = validate_stack_config(config)
         self.assertIn("At least one ingest must be enabled", errors)
 
+    def test_rejects_invalid_hls_playlist(self):
+        config = load_defaults()
+        config["hls"]["playlist"] = 'stream"><script>alert(1)</script>'
+        errors = validate_stack_config(config)
+        self.assertTrue(any("hls.playlist" in error for error in errors))
+
+    def test_rejects_null_output_samplerate(self):
+        config = load_defaults()
+        config["outputs"][0]["samplerate"] = None
+        errors = validate_stack_config(config)
+        self.assertTrue(any("samplerate" in error for error in errors))
+
+    def test_rejects_invalid_ingest_id(self):
+        config = load_defaults()
+        config["ingests"][0]["id"] = "my-ingest"
+        errors = validate_stack_config(config)
+        self.assertTrue(any("ingests.0.id" in error for error in errors))
+
 
 class StackRenderTests(unittest.TestCase):
     def setUp(self):

--- a/config/stack.defaults.json
+++ b/config/stack.defaults.json
@@ -1,0 +1,105 @@
+{
+  "version": 1,
+  "ingests": [
+    {
+      "id": "primary",
+      "type": "harbor",
+      "port": 8010,
+      "priority": 1,
+      "enabled": true
+    },
+    {
+      "id": "secondary",
+      "type": "harbor",
+      "port": 8011,
+      "priority": 2,
+      "enabled": true
+    }
+  ],
+  "outputs": [
+    {
+      "id": "mp3-128",
+      "type": "icecast",
+      "mount": "/stream-mp3-128",
+      "codec": "mp3",
+      "bitrate": 128,
+      "samplerate": 44100,
+      "channels": 2,
+      "enabled": true
+    },
+    {
+      "id": "mp3-192",
+      "type": "icecast",
+      "mount": "/stream-mp3-192",
+      "codec": "mp3",
+      "bitrate": 192,
+      "samplerate": 44100,
+      "channels": 2,
+      "enabled": true
+    },
+    {
+      "id": "mp3-320",
+      "type": "icecast",
+      "mount": "/stream-mp3-320",
+      "codec": "mp3",
+      "bitrate": 320,
+      "samplerate": 44100,
+      "channels": 2,
+      "enabled": true
+    },
+    {
+      "id": "aac-128",
+      "type": "icecast",
+      "mount": "/stream-aac-128",
+      "codec": "fdkaac",
+      "bitrate": 128,
+      "samplerate": 44100,
+      "channels": 2,
+      "enabled": true
+    },
+    {
+      "id": "aac-192",
+      "type": "icecast",
+      "mount": "/stream-aac-192",
+      "codec": "fdkaac",
+      "bitrate": 192,
+      "samplerate": 44100,
+      "channels": 2,
+      "enabled": true
+    },
+    {
+      "id": "ogg-128",
+      "type": "icecast",
+      "mount": "/stream-ogg-128",
+      "codec": "vorbis",
+      "bitrate": 128,
+      "samplerate": 44100,
+      "channels": 2,
+      "enabled": true
+    }
+  ],
+  "hls": {
+    "enabled": true,
+    "playlist": "live.m3u8",
+    "segment_duration": 4.0,
+    "variants": [
+      {
+        "id": "aac_64",
+        "bitrate": 64
+      },
+      {
+        "id": "aac_128",
+        "bitrate": 128
+      },
+      {
+        "id": "aac_256",
+        "bitrate": 256
+      }
+    ]
+  },
+  "processing": {
+    "crossfade_seconds": 0.35,
+    "buffer_seconds": 6.0,
+    "max_buffer_seconds": 25.0
+  }
+}

--- a/config/stack.schema.json
+++ b/config/stack.schema.json
@@ -19,7 +19,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^[a-z][a-z0-9-]*$"
+            "pattern": "^[a-z][a-z0-9_]*$"
           },
           "type": {
             "type": "string",

--- a/config/stack.schema.json
+++ b/config/stack.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Sonicverse Stack Config",
+  "type": "object",
+  "required": ["version", "ingests", "outputs", "hls", "processing"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "ingests": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "port", "priority", "enabled"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          },
+          "type": {
+            "type": "string",
+            "const": "harbor"
+          },
+          "port": {
+            "type": "integer",
+            "minimum": 1024,
+            "maximum": 65535
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "outputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "mount",
+          "codec",
+          "bitrate",
+          "samplerate",
+          "channels",
+          "enabled"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          },
+          "type": {
+            "type": "string",
+            "const": "icecast"
+          },
+          "mount": {
+            "type": "string",
+            "pattern": "^/[a-z0-9-]+$"
+          },
+          "codec": {
+            "type": "string",
+            "enum": ["mp3", "fdkaac", "vorbis"]
+          },
+          "bitrate": {
+            "type": "integer",
+            "minimum": 32,
+            "maximum": 512
+          },
+          "samplerate": {
+            "type": "integer",
+            "enum": [44100, 48000]
+          },
+          "channels": {
+            "type": "integer",
+            "enum": [1, 2]
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "hls": {
+      "type": "object",
+      "required": ["enabled", "playlist", "segment_duration", "variants"],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "playlist": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9._-]+$"
+        },
+        "segment_duration": {
+          "type": "number",
+          "minimum": 2,
+          "maximum": 10
+        },
+        "variants": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "bitrate"],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9_]*$"
+              },
+              "bitrate": {
+                "type": "integer",
+                "minimum": 32,
+                "maximum": 512
+              }
+            }
+          }
+        }
+      }
+    },
+    "processing": {
+      "type": "object",
+      "required": ["crossfade_seconds", "buffer_seconds", "max_buffer_seconds"],
+      "additionalProperties": false,
+      "properties": {
+        "crossfade_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 5
+        },
+        "buffer_seconds": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 30
+        },
+        "max_buffer_seconds": {
+          "type": "number",
+          "minimum": 5,
+          "maximum": 60
+        }
+      }
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     volumes:
       - hls-data:/hls
       - icecast-logs:/var/log/icecast2
+      - ./stack-config:/etc/sonicverse
       - ./certbot/conf:/etc/letsencrypt:ro
       - ./certbot/www:/var/www/certbot:ro
       - ./emergency-audio:/emergency-audio
@@ -69,8 +70,13 @@ services:
       - STATUS_PANEL_WRITE_ROLES=${STATUS_PANEL_WRITE_ROLES:-owner,admin}
       - STATUS_PANEL_ALLOW_RISKY_COMMANDS=${STATUS_PANEL_ALLOW_RISKY_COMMANDS:-0}
       - EMERGENCY_AUDIO_DIR=/emergency-audio
+      - STACK_CONFIG_PATH=/etc/sonicverse/stack.json
+      - STACK_APPLY_STATUS_PATH=/etc/sonicverse/stack.apply.json
+      - STACK_ALLOWED_INGEST_PORTS=${STACK_ALLOWED_INGEST_PORTS:-8010,8011}
+      - STACK_APPLY_TIMEOUT_S=${STACK_APPLY_TIMEOUT_S:-120}
     volumes:
       - ./emergency-audio:/emergency-audio
+      - ./stack-config:/etc/sonicverse
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - streaming

--- a/infrastructure/nginx/index.streams.html.j2
+++ b/infrastructure/nginx/index.streams.html.j2
@@ -1,0 +1,23 @@
+        <div class="section-title">Available Streams</div>
+        <div class="endpoints-grid">
+{% for output in outputs %}
+{% if output.enabled %}
+            <a href="/listen{{ output.mount }}" class="endpoint-card" target="_blank" rel="noopener noreferrer">
+                <div class="endpoint-info">
+                    <h3>{{ output.label }}</h3>
+                    <p>{{ output.description }}</p>
+                </div>
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+            </a>
+{% endif %}
+{% endfor %}
+{% if hls.enabled %}
+            <a href="/hls/{{ hls.playlist }}" class="endpoint-card" target="_blank" rel="noopener noreferrer">
+                <div class="endpoint-info">
+                    <h3>HLS Stream</h3>
+                    <p>Adaptive bitrate • Modern web players</p>
+                </div>
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+            </a>
+{% endif %}
+        </div>

--- a/scripts/render-stack-config.sh
+++ b/scripts/render-stack-config.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHONPATH="/opt/sonicverse/status-api:${PYTHONPATH:-}"
+export PYTHONPATH
+
+python3 - <<'PY'
+from stack.apply import pre_render_config
+from stack.store import read_config
+
+pre_render_config(read_config())
+print("[render] Stack config rendered")
+PY

--- a/scripts/request-streaming-reload.sh
+++ b/scripts/request-streaming-reload.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELOAD_MARKER="${STACK_RELOAD_MARKER_PATH:-/run/sonicverse/reload-request}"
+mkdir -p "$(dirname "$RELOAD_MARKER")"
+date +%s > "$RELOAD_MARKER"
+echo "[reload] Requested streaming reload at $(cat "$RELOAD_MARKER")"

--- a/scripts/unified-entrypoint.sh
+++ b/scripts/unified-entrypoint.sh
@@ -11,6 +11,13 @@ STATUS_PANEL_ENABLED="${ENABLE_STATUS_PANEL:-0}"
 RENDERED_CONFIG_PATH="/etc/nginx/rendered/nginx.conf"
 FINAL_CONFIG_PATH="/etc/nginx/nginx.conf"
 RELOAD_MARKER="/etc/letsencrypt/.nginx-reload"
+STACK_RELOAD_MARKER="${STACK_RELOAD_MARKER_PATH:-/run/sonicverse/reload-request}"
+STACK_CONFIG_PATH="${STACK_CONFIG_PATH:-/etc/sonicverse/stack.json}"
+STACK_DEFAULTS_PATH="${STACK_DEFAULTS_PATH:-/opt/sonicverse/config/stack.defaults.json}"
+RELOADING=0
+
+ICECAST_PID=""
+LIQUIDSOAP_PID=""
 
 log() {
     echo "[entrypoint] $*"
@@ -28,8 +35,35 @@ marker_value() {
     fi
 }
 
+stack_reload_marker_value() {
+    if [[ -f "$STACK_RELOAD_MARKER" ]]; then
+        cat "$STACK_RELOAD_MARKER" 2>/dev/null || echo 0
+    else
+        echo 0
+    fi
+}
+
+seed_stack_config() {
+    mkdir -p "$(dirname "$STACK_CONFIG_PATH")"
+    if [[ ! -f "$STACK_CONFIG_PATH" && -f "$STACK_DEFAULTS_PATH" ]]; then
+        log "Seeding stack config from defaults"
+        cp "$STACK_DEFAULTS_PATH" "$STACK_CONFIG_PATH"
+    fi
+}
+
+render_stack_config() {
+    if [[ -f "$STACK_CONFIG_PATH" ]]; then
+        log "Rendering stack config"
+        /usr/local/bin/render-stack-config.sh
+    else
+        log "No stack config found; using baked-in service configs"
+    fi
+}
+
 render_icecast_config() {
-    envsubst < /etc/icecast2/icecast.xml.template > /etc/icecast2/icecast.xml
+    if [[ -f /etc/icecast2/icecast.xml.template ]]; then
+        envsubst < /etc/icecast2/icecast.xml.template > /etc/icecast2/icecast.xml
+    fi
 }
 
 write_nginx_config() {
@@ -58,9 +92,13 @@ render_nginx_config() {
     STATION_NAME_ESC="$(escape_html "$FINAL_RADIO_NAME")"
     STATION_ADMIN_EMAIL_ESC="$(escape_html "$FINAL_CONTACT_EMAIL")"
 
-    envsubst '$STATION_NAME_ESC $STATION_ADMIN_EMAIL_ESC $ICECAST_HOSTNAME' \
-        < /etc/nginx/index.html.template \
-        > /usr/share/nginx/html/index.html
+    if [[ -f /usr/share/nginx/html/index.html ]]; then
+        log "Using rendered landing page from stack config"
+    else
+        envsubst '$STATION_NAME_ESC $STATION_ADMIN_EMAIL_ESC $ICECAST_HOSTNAME' \
+            < /etc/nginx/index.html.template \
+            > /usr/share/nginx/html/index.html
+    fi
 
     write_nginx_config
 }
@@ -88,14 +126,35 @@ watch_certificate_updates() {
     done
 }
 
+update_service_pid() {
+    local name="$1"
+    local pid="$2"
+    local index
+
+    for index in "${!SERVICE_NAMES[@]}"; do
+        if [[ "${SERVICE_NAMES[$index]}" == "$name" ]]; then
+            SERVICE_PIDS[$index]="$pid"
+            return 0
+        fi
+    done
+
+    SERVICE_NAMES+=("$name")
+    SERVICE_PIDS+=("$pid")
+}
+
 start_service() {
     local name="$1"
     shift
 
     log "Starting $name"
     "$@" &
-    SERVICE_NAMES+=("$name")
-    SERVICE_PIDS+=("$!")
+    local pid="$!"
+    update_service_pid "$name" "$pid"
+
+    case "$name" in
+        icecast) ICECAST_PID="$pid" ;;
+        liquidsoap) LIQUIDSOAP_PID="$pid" ;;
+    esac
 }
 
 wait_for_url() {
@@ -112,6 +171,95 @@ wait_for_url() {
 
     log "$name did not become ready at $url"
     return 1
+}
+
+stop_pid() {
+    local pid="$1"
+    local name="$2"
+
+    if [[ -z "$pid" ]]; then
+        return 0
+    fi
+
+    if kill -0 "$pid" 2>/dev/null; then
+        log "Stopping $name (pid $pid)"
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+    fi
+}
+
+validate_streaming_config() {
+    if ! liquidsoap --check /etc/liquidsoap/radio.liq; then
+        log "Liquidsoap config validation failed"
+        return 1
+    fi
+
+    if ! render_icecast_config; then
+        log "Icecast config render failed"
+        return 1
+    fi
+
+    return 0
+}
+
+reload_streaming_services() {
+    log "Supervised streaming reload requested"
+    RELOADING=1
+
+    render_stack_config
+
+    if ! validate_streaming_config; then
+        RELOADING=0
+        return 1
+    fi
+
+    stop_pid "$LIQUIDSOAP_PID" "liquidsoap"
+    stop_pid "$ICECAST_PID" "icecast"
+
+    icecast2 -c /etc/icecast2/icecast.xml &
+    ICECAST_PID="$!"
+    update_service_pid "icecast" "$ICECAST_PID"
+
+    if ! wait_for_url icecast "http://127.0.0.1:8000/status-json.xsl"; then
+        RELOADING=0
+        return 1
+    fi
+
+    liquidsoap /etc/liquidsoap/radio.liq &
+    LIQUIDSOAP_PID="$!"
+    update_service_pid "liquidsoap" "$LIQUIDSOAP_PID"
+
+    if nginx -t; then
+        nginx -s reload || true
+    fi
+
+    RELOADING=0
+    log "Supervised streaming reload complete"
+    return 0
+}
+
+watch_reload_requests() {
+    local last_marker
+    local current_marker
+
+    mkdir -p "$(dirname "$STACK_RELOAD_MARKER")"
+    last_marker="$(stack_reload_marker_value)"
+
+    while :; do
+        sleep 2
+        current_marker="$(stack_reload_marker_value)"
+
+        if [[ "$current_marker" != "$last_marker" ]]; then
+            last_marker="$current_marker"
+            if reload_streaming_services; then
+                printf '{"state":"applied","updated_at":%s}\n' "$(date +%s)" \
+                    > /etc/sonicverse/stack.apply.json
+            else
+                printf '{"state":"failed","error":"supervised reload failed","updated_at":%s}\n' "$(date +%s)" \
+                    > /etc/sonicverse/stack.apply.json
+            fi
+        fi
+    done
 }
 
 stop_services() {
@@ -155,6 +303,12 @@ monitor_services() {
         set -e
 
         failed_name="$(service_name_for_pid "$failed_pid")"
+
+        if [[ "$RELOADING" == "1" && ( "$failed_name" == "icecast" || "$failed_name" == "liquidsoap" ) ]]; then
+            log "$failed_name exited during supervised reload (status $exit_code); continuing"
+            continue
+        fi
+
         log "$failed_name exited with status $exit_code; stopping container"
         stop_services
         exit "$exit_code"
@@ -166,6 +320,8 @@ mkdir -p \
     /emergency-audio \
     /hls \
     /run/nginx \
+    /run/sonicverse \
+    /etc/sonicverse \
     /usr/share/nginx/html \
     /var/cache/nginx/client_temp \
     /var/cache/nginx/proxy_temp \
@@ -174,6 +330,8 @@ mkdir -p \
     /var/cache/nginx/scgi_temp \
     /var/log/icecast2
 
+seed_stack_config
+render_stack_config
 render_icecast_config
 render_nginx_config
 
@@ -195,5 +353,6 @@ fi
 start_service liquidsoap liquidsoap /etc/liquidsoap/radio.liq
 start_service nginx nginx -g "daemon off;"
 start_service certificate-watch watch_certificate_updates
+start_service stack-reload-watch watch_reload_requests
 
 monitor_services

--- a/scripts/unified-entrypoint.sh
+++ b/scripts/unified-entrypoint.sh
@@ -18,6 +18,10 @@ RELOADING=0
 
 ICECAST_PID=""
 LIQUIDSOAP_PID=""
+LIQUIDSOAP_CONFIG="/etc/liquidsoap/radio.liq"
+ICECAST_TEMPLATE="/etc/icecast2/icecast.xml.template"
+ICECAST_CONFIG="/etc/icecast2/icecast.xml"
+STACK_APPLY_STATUS="/etc/sonicverse/stack.apply.json"
 
 log() {
     echo "[entrypoint] $*"
@@ -188,6 +192,66 @@ stop_pid() {
     fi
 }
 
+backup_streaming_configs() {
+    local path
+
+    for path in "$LIQUIDSOAP_CONFIG" "$ICECAST_TEMPLATE" "$ICECAST_CONFIG"; do
+        if [[ -f "$path" ]]; then
+            cp "$path" "${path}.bak"
+        fi
+    done
+}
+
+restore_streaming_configs() {
+    local path
+
+    for path in "$LIQUIDSOAP_CONFIG" "$ICECAST_TEMPLATE" "$ICECAST_CONFIG"; do
+        if [[ -f "${path}.bak" ]]; then
+            cp "${path}.bak" "$path"
+        fi
+    done
+}
+
+write_stack_apply_status() {
+    local state="$1"
+    local error_message="${2:-supervised reload failed}"
+    local temp="${STACK_APPLY_STATUS}.tmp.$$"
+    local timestamp
+
+    timestamp="$(date +%s)"
+    mkdir -p "$(dirname "$STACK_APPLY_STATUS")"
+
+    if [[ "$state" == "applied" ]]; then
+        printf '{"state":"applied","updated_at":%s}\n' "$timestamp" > "$temp"
+    else
+        printf '{"state":"failed","error":"%s","updated_at":%s}\n' \
+            "$error_message" "$timestamp" > "$temp"
+    fi
+    mv "$temp" "$STACK_APPLY_STATUS"
+}
+
+start_streaming_services() {
+    icecast2 -c "$ICECAST_CONFIG" &
+    ICECAST_PID="$!"
+    update_service_pid "icecast" "$ICECAST_PID"
+
+    if ! wait_for_url icecast "http://127.0.0.1:8000/status-json.xsl"; then
+        return 1
+    fi
+
+    liquidsoap "$LIQUIDSOAP_CONFIG" &
+    LIQUIDSOAP_PID="$!"
+    update_service_pid "liquidsoap" "$LIQUIDSOAP_PID"
+    return 0
+}
+
+rollback_streaming_services() {
+    log "Restarting previous streaming services after reload failure"
+    stop_pid "$ICECAST_PID" "icecast"
+    restore_streaming_configs
+    start_streaming_services
+}
+
 validate_streaming_config() {
     if ! liquidsoap --check /etc/liquidsoap/radio.liq; then
         log "Liquidsoap config validation failed"
@@ -206,9 +270,16 @@ reload_streaming_services() {
     log "Supervised streaming reload requested"
     RELOADING=1
 
-    render_stack_config
+    backup_streaming_configs
+
+    if ! render_stack_config; then
+        restore_streaming_configs
+        RELOADING=0
+        return 1
+    fi
 
     if ! validate_streaming_config; then
+        restore_streaming_configs
         RELOADING=0
         return 1
     fi
@@ -216,18 +287,11 @@ reload_streaming_services() {
     stop_pid "$LIQUIDSOAP_PID" "liquidsoap"
     stop_pid "$ICECAST_PID" "icecast"
 
-    icecast2 -c /etc/icecast2/icecast.xml &
-    ICECAST_PID="$!"
-    update_service_pid "icecast" "$ICECAST_PID"
-
-    if ! wait_for_url icecast "http://127.0.0.1:8000/status-json.xsl"; then
+    if ! start_streaming_services; then
+        rollback_streaming_services || true
         RELOADING=0
         return 1
     fi
-
-    liquidsoap /etc/liquidsoap/radio.liq &
-    LIQUIDSOAP_PID="$!"
-    update_service_pid "liquidsoap" "$LIQUIDSOAP_PID"
 
     if nginx -t; then
         nginx -s reload || true
@@ -252,11 +316,9 @@ watch_reload_requests() {
         if [[ "$current_marker" != "$last_marker" ]]; then
             last_marker="$current_marker"
             if reload_streaming_services; then
-                printf '{"state":"applied","updated_at":%s}\n' "$(date +%s)" \
-                    > /etc/sonicverse/stack.apply.json
+                write_stack_apply_status "applied"
             else
-                printf '{"state":"failed","error":"supervised reload failed","updated_at":%s}\n' "$(date +%s)" \
-                    > /etc/sonicverse/stack.apply.json
+                write_stack_apply_status "failed" "supervised reload failed"
             fi
         fi
     done

--- a/services/streaming/icecast/icecast.xml.j2
+++ b/services/streaming/icecast/icecast.xml.j2
@@ -1,0 +1,67 @@
+<icecast>
+    <location>${STATION_LOCATION}</location>
+    <admin>${STATION_ADMIN_EMAIL}</admin>
+
+    <limits>
+        <clients>${ICECAST_MAX_LISTENERS}</clients>
+        <sources>12</sources>
+        <queue-size>524288</queue-size>
+        <client-timeout>30</client-timeout>
+        <header-timeout>15</header-timeout>
+        <source-timeout>10</source-timeout>
+        <burst-on-connect>1</burst-on-connect>
+        <burst-size>65535</burst-size>
+    </limits>
+
+    <authentication>
+        <source-password>${ICECAST_SOURCE_PASSWORD}</source-password>
+        <relay-password>${ICECAST_RELAY_PASSWORD}</relay-password>
+        <admin-user>${ICECAST_ADMIN_USER}</admin-user>
+        <admin-password>${ICECAST_ADMIN_PASSWORD}</admin-password>
+    </authentication>
+
+    <hostname>${ICECAST_HOSTNAME}</hostname>
+
+    <listen-socket>
+        <port>8000</port>
+    </listen-socket>
+
+    <http-headers>
+        <header name="Access-Control-Allow-Origin" value="*" />
+    </http-headers>
+
+    <!-- Mount points for each output format -->
+{% for output in outputs %}
+{% if output.enabled %}
+    <mount type="normal">
+        <mount-name>{{ output.mount }}</mount-name>
+        <charset>UTF-8</charset>
+        <public>1</public>
+    </mount>
+{% endif %}
+{% endfor %}
+
+    <fileserve>1</fileserve>
+
+    <paths>
+        <basedir>/usr/share/icecast2</basedir>
+        <logdir>/var/log/icecast2</logdir>
+        <webroot>/usr/share/icecast2/web</webroot>
+        <adminroot>/usr/share/icecast2/admin</adminroot>
+        <alias source="/" destination="/status.xsl"/>
+    </paths>
+
+    <logging>
+        <accesslog>access.log</accesslog>
+        <errorlog>error.log</errorlog>
+        <loglevel>3</loglevel>
+    </logging>
+
+    <security>
+        <chroot>0</chroot>
+        <changeowner>
+            <user>icecast2</user>
+            <group>icecast</group>
+        </changeowner>
+    </security>
+</icecast>

--- a/services/streaming/liquidsoap/radio.liq.j2
+++ b/services/streaming/liquidsoap/radio.liq.j2
@@ -1,0 +1,132 @@
+# ============================================================
+# Liquidsoap Configuration (generated from stack config)
+# ============================================================
+
+# --- Settings ---
+settings.harbor.bind_addrs.set(["0.0.0.0"])
+settings.log.level.set(3)
+settings.init.allow_root.set(true)
+
+# Frame & buffering settings for stability
+settings.frame.duration.set(0.04)
+
+station_name = environment.get(default="Radio Station", "STATION_NAME")
+harbor_password = environment.get(default="changeme", "HARBOR_PASSWORD")
+icecast_pass = environment.get(default="changeme", "ICECAST_SOURCE_PASSWORD")
+icecast_host = environment.get(default="127.0.0.1", "ICECAST_INTERNAL_HOST")
+icecast_port = 8000
+
+# --- Inputs from studio ---
+{% for ingest in ingests | sort(attribute='priority') %}
+{% if ingest.enabled %}
+{{ ingest.id }} = input.harbor(
+  "{{ ingest.id }}",
+  port={{ ingest.port }},
+  password=harbor_password,
+  max=45.0,
+  buffer=15.0
+)
+
+{{ ingest.id }}.on_connect(synchronous=false, fun (_) -> begin
+  log("OK: {{ ingest.id | capitalize }} harbor connected")
+end)
+
+{{ ingest.id }}.on_disconnect(synchronous=false, fun () -> begin
+  log("ALERT: {{ ingest.id | capitalize }} harbor disconnected")
+end)
+{% endif %}
+{% endfor %}
+
+# --- Emergency fallback ---
+emergency = playlist("/emergency-audio", mode="normal", reload_mode="watch", reload=5)
+silence = blank()
+
+# --- Fallback chain ---
+radio = fallback(
+  track_sensitive=false,
+  [{% for ingest in ingests | sort(attribute='priority') %}{% if ingest.enabled %}{{ ingest.id }}, {% endif %}{% endfor %}emergency, silence]
+)
+
+radio = crossfade(duration={{ processing.crossfade_seconds }}, radio)
+
+radio = buffer(buffer={{ processing.buffer_seconds }}, max={{ processing.max_buffer_seconds }}, radio)
+
+radio = mksafe(radio)
+
+# --- Silence detection ---
+silence_threshold = float_of_string(environment.get(default="-40", "SILENCE_THRESHOLD_DB"))
+silence_duration = float_of_string(environment.get(default="15", "SILENCE_DURATION"))
+
+radio = blank.detect(
+  radio,
+  max_blank=silence_duration,
+  threshold=silence_threshold
+)
+
+radio.on_blank(synchronous=false, fun () -> begin
+  log("ALERT: Silence detected for #{silence_duration}s (threshold: #{silence_threshold}dB)")
+end)
+
+radio.on_noise(synchronous=false, fun () -> begin
+  log("OK: Audio resumed after silence")
+end)
+
+# --- Icecast outputs ---
+{% for output in outputs %}
+{% if output.enabled %}
+{% if output.codec == 'mp3' %}
+output.icecast(
+  %mp3(bitrate={{ output.bitrate }}, samplerate={{ output.samplerate }}, stereo={{ 'true' if output.channels == 2 else 'false' }}),
+  host=icecast_host, port=icecast_port,
+  password=icecast_pass,
+  mount="{{ output.mount }}",
+  name="#{station_name} - MP3 {{ output.bitrate }}k",
+  description=station_name,
+  radio
+)
+{% elif output.codec == 'fdkaac' %}
+output.icecast(
+  %fdkaac(bitrate={{ output.bitrate }}, channels={{ output.channels }}, samplerate={{ output.samplerate }}),
+  host=icecast_host, port=icecast_port,
+  password=icecast_pass,
+  mount="{{ output.mount }}",
+  name="#{station_name} - AAC {{ output.bitrate }}k",
+  description=station_name,
+  radio
+)
+{% elif output.codec == 'vorbis' %}
+output.icecast(
+  %vorbis.cbr(bitrate={{ output.bitrate }}, channels={{ output.channels }}, samplerate={{ output.samplerate }}),
+  host=icecast_host, port=icecast_port,
+  password=icecast_pass,
+  mount="{{ output.mount }}",
+  name="#{station_name} - Ogg {{ output.bitrate }}k",
+  description=station_name,
+  radio
+)
+{% endif %}
+{% endif %}
+{% endfor %}
+
+# --- HLS output ---
+{% if hls.enabled and hls.variants %}
+output.file.hls(
+  "/hls",
+  segment_duration={{ hls.segment_duration }},
+  segments=6,
+  segments_overhead=12,
+  perm=0o644,
+  playlist="{{ hls.playlist }}",
+  [
+{% for variant in hls.variants %}
+    ("{{ variant.id }}",
+      %ffmpeg(format="mpegts",
+        %audio(codec="aac", b="{{ variant.bitrate }}k", channels=2, ar=44100)
+      )
+    ){% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+  radio
+)
+{% endif %}


### PR DESCRIPTION
## Summary

Adds a backend control plane to status-api so operators can manage streaming topology without hand-editing config files or restarting the whole stack.

- Introduces canonical stack config (`config/stack.defaults.json`) persisted on a shared `./stack-config` volume
- Renders Icecast, Liquidsoap, and landing-page stream cards from Jinja2 templates
- Exposes `/api/stack/*` endpoints for reading/updating ingests and outputs, applying changes, and checking health
- Applies changes via supervised in-container Icecast/Liquidsoap reload (entrypoint reload watcher)

Primary documentation source: https://docs.sonicverse.tech

## Related GitHub issue

Related to #151

## Test plan

- [x] `ruff check apps/status-api/`
- [x] `PYTHONPATH=apps/status-api python -m unittest discover -s apps/status-api/tests`
- [ ] `docker compose up -d --build` and verify stack seeds `stack-config/stack.json` on first boot
- [ ] With `ENABLE_STATUS_PANEL=1`, call `GET /api/stack/config` and `POST /api/stack/apply` as an operator
- [ ] Confirm `GET /api/stack/health` reports expected mounts after apply


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a stack config control plane for the streaming stack. The main changes are:

- New `/api/stack/*` endpoints for config, ingests, outputs, apply, and health.
- Shared persisted stack config with defaults and JSON Schema validation.
- Jinja-rendered Icecast, Liquidsoap, and landing-page stream configs.
- Supervised streaming reload support through the container entrypoint.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the primary request/response evidence in the status-api-stack-02-after.log to confirm HTTP status codes and reason phrases for each endpoint.
- Checked the server startup and runtime handler logs in status-api-stack-server.log and verified Appwrite auth is enabled, with endpoint results including GET /api/stack/config 200, POST /api/stack/apply 502, and GET /api/stack/health 200.
- Verified that the failed apply status was persisted in status-api-stack-apply.json.
- Reviewed status-api-stack-summary.json to understand the Docker unavailability blocking completion of the reload/render cycle.

<a href="https://app.greptile.com/trex/runs/14316690/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/status-api/stack/schema.py | Adds schema-backed validation before stack config is persisted or applied. |
| config/stack.schema.json | Defines the accepted stack config shape for ingests, outputs, HLS, and processing. |
| apps/status-api/stack/store.py | Adds persisted stack config and apply-status reads and writes. |
| scripts/unified-entrypoint.sh | Adds stack config rendering, reload watching, service restart, and rollback handling. |

<sub>Reviews (2): Last reviewed commit: ["Fix stack config validation and supervis..."](https://github.com/sonicverse-eu/audiostreaming-stack/commit/c4098def5ae1ea73c0267d179d1d25fae7f8d4c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43979387)</sub>

<!-- /greptile_comment -->